### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/sqlg-core/src/main/java/org/umlg/sqlg/strategy/SqlgSqlExecutor.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/strategy/SqlgSqlExecutor.java
@@ -26,6 +26,8 @@ public class SqlgSqlExecutor {
 
     private static Logger logger = LoggerFactory.getLogger(SqlgSqlExecutor.class.getName());
 
+    private SqlgSqlExecutor() {}
+
     public static <E extends SqlgElement> void executeRegularQueries(
             SqlgGraph sqlgGraph, SchemaTableTree rootSchemaTableTree, RecordId recordId,
             SqlgCompiledResultIterator<Pair<E, Multimap<String, Emit<E>>>> resultIterator) {

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgExceptions.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgExceptions.java
@@ -6,6 +6,8 @@ package org.umlg.sqlg.structure;
  */
 public class SqlgExceptions {
 
+    private SqlgExceptions() {}
+
     public static InvalidIdException invalidId(String invalidId) {
         return new InvalidIdException("Sqlg ids must be a String with the format 'label:::id' The id must be a long. The given id " + invalidId + " is invalid.");
     }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/TopologyManager.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/TopologyManager.java
@@ -16,6 +16,8 @@ import java.util.Map;
  */
 public class TopologyManager {
 
+    private TopologyManager() {}
+
     static Vertex addSchema(SqlgGraph sqlgGraph, String schema) {
         BatchManager.BatchModeType batchModeType = flushAndSetTxToNone(sqlgGraph);
         try {

--- a/sqlg-core/src/main/java/org/umlg/sqlg/util/SqlgUtil.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/util/SqlgUtil.java
@@ -34,6 +34,8 @@ public class SqlgUtil {
     //As it happens postgres join to temp is always faster except for count = 1 when in is not used but '='
     private final static int BULK_WITHIN_COUNT = 1;
 
+    private SqlgUtil() {}
+
     public static <E extends SqlgElement> Multimap<String, Emit<E>> loadLabeledElements(
             SqlgGraph sqlgGraph, final ResultSet resultSet,
             LinkedList<SchemaTableTree> subQueryStack, int subQueryCount, AliasMapHolder copyAliasMapHolder,

--- a/sqlg-core/src/main/java/org/umlg/sqlg/util/StreamFactory.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/util/StreamFactory.java
@@ -10,6 +10,8 @@ import java.util.stream.StreamSupport;
  */
 public class StreamFactory {
 
+    private StreamFactory() {}
+
     public  static <T> Stream<T> stream(Iterator<T> iter) {
         Iterable<T> iterable = () -> iter;
         return StreamSupport.stream(iterable.spliterator(), false);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava