### PR TITLE
squid:S1192 - String literals should not be duplicated

### DIFF
--- a/sqlg-core/src/main/java/org/umlg/sqlg/sql/parse/WhereClause.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/sql/parse/WhereClause.java
@@ -20,6 +20,8 @@ import java.util.Collection;
  */
 public class WhereClause {
 
+    public static final String LIKE = " like ?";
+    public static final String NOT_LIKE = " not like ?";
     private P p;
 
     private WhereClause(P p) {
@@ -138,10 +140,10 @@ public class WhereClause {
         String result;
         switch (text) {
             case contains:
-                result = " like ?";
+                result = LIKE;
                 break;
             case ncontains:
-                result = " not like ?";
+                result = NOT_LIKE;
                 break;
             case containsCIS:
                 if (!sqlDialect.supportsILike()) {
@@ -164,16 +166,16 @@ public class WhereClause {
                 }
                 break;
             case startsWith:
-                result = " like ?";
+                result = LIKE;
                 break;
             case nstartsWith:
-                result = " not like ?";
+                result = NOT_LIKE;
                 break;
             case endsWith:
-                result = " like ?";
+                result = LIKE;
                 break;
             case nendsWith:
-                result = " not like ?";
+                result = NOT_LIKE;
                 break;
             default:
                 throw new RuntimeException("Unknown Contains " + text.name());

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SchemaManager.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SchemaManager.java
@@ -32,6 +32,12 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 public class SchemaManager {
 
+    public static final String JDBC_URL = "jdbc.url";
+    public static final String GIVEN_TABLES_MUST_NOT_BE_NULL = "Given tables must not be null";
+    public static final String GIVEN_TABLE_MUST_NOT_BE_NULL = "Given table must not be null";
+    public static final String CREATED_ON = "createdOn";
+    public static final String SHOULD_NOT_HAPPEN = "Should not happen!";
+
     private Logger logger = LoggerFactory.getLogger(SchemaManager.class.getName());
 
     /**
@@ -150,11 +156,11 @@ public class SchemaManager {
 
         if (this.distributed) {
             this.hazelcastInstance = Hazelcast.newHazelcastInstance(configHazelcast(configuration));
-            this.schemas = this.hazelcastInstance.getMap(this.sqlgGraph.getConfiguration().getString("jdbc.url") + SCHEMAS_HAZELCAST_MAP);
-            this.labelSchemas = this.hazelcastInstance.getMap(this.sqlgGraph.getConfiguration().getString("jdbc.url") + LABEL_SCHEMAS_HAZELCAST_MAP);
-            this.tables = this.hazelcastInstance.getMap(this.sqlgGraph.getConfiguration().getString("jdbc.url") + TABLES_HAZELCAST_MAP);
-            this.edgeForeignKeys = this.hazelcastInstance.getMap(this.sqlgGraph.getConfiguration().getString("jdbc.url") + EDGE_FOREIGN_KEYS_HAZELCAST_MAP);
-            this.tableLabels = this.hazelcastInstance.getMap(this.sqlgGraph.getConfiguration().getString("jdbc.url") + TABLE_LABELS_HAZELCAST_MAP);
+            this.schemas = this.hazelcastInstance.getMap(this.sqlgGraph.getConfiguration().getString(JDBC_URL) + SCHEMAS_HAZELCAST_MAP);
+            this.labelSchemas = this.hazelcastInstance.getMap(this.sqlgGraph.getConfiguration().getString(JDBC_URL) + LABEL_SCHEMAS_HAZELCAST_MAP);
+            this.tables = this.hazelcastInstance.getMap(this.sqlgGraph.getConfiguration().getString(JDBC_URL) + TABLES_HAZELCAST_MAP);
+            this.edgeForeignKeys = this.hazelcastInstance.getMap(this.sqlgGraph.getConfiguration().getString(JDBC_URL) + EDGE_FOREIGN_KEYS_HAZELCAST_MAP);
+            this.tableLabels = this.hazelcastInstance.getMap(this.sqlgGraph.getConfiguration().getString(JDBC_URL) + TABLE_LABELS_HAZELCAST_MAP);
             ((IMap) this.schemas).addEntryListener(new SchemasMapEntryListener(), true);
             ((IMap) this.labelSchemas).addEntryListener(new LabelSchemasMapEntryListener(), true);
             ((IMap) this.tables).addEntryListener(new TablesMapEntryListener(), true);
@@ -305,27 +311,27 @@ public class SchemaManager {
         NearCacheConfig nearCacheConfig = new NearCacheConfig();
 
         MapConfig schemaMapConfig = new MapConfig();
-        schemaMapConfig.setName(this.sqlgGraph.getConfiguration().getString("jdbc.url") + SCHEMAS_HAZELCAST_MAP);
+        schemaMapConfig.setName(this.sqlgGraph.getConfiguration().getString(JDBC_URL) + SCHEMAS_HAZELCAST_MAP);
         schemaMapConfig.setNearCacheConfig(nearCacheConfig);
         config.addMapConfig(schemaMapConfig);
 
         MapConfig labelSchemasMapConfig = new MapConfig();
-        labelSchemasMapConfig.setName(this.sqlgGraph.getConfiguration().getString("jdbc.url") + LABEL_SCHEMAS_HAZELCAST_MAP);
+        labelSchemasMapConfig.setName(this.sqlgGraph.getConfiguration().getString(JDBC_URL) + LABEL_SCHEMAS_HAZELCAST_MAP);
         labelSchemasMapConfig.setNearCacheConfig(nearCacheConfig);
         config.addMapConfig(labelSchemasMapConfig);
 
         MapConfig tableMapConfig = new MapConfig();
-        tableMapConfig.setName(this.sqlgGraph.getConfiguration().getString("jdbc.url") + TABLES_HAZELCAST_MAP);
+        tableMapConfig.setName(this.sqlgGraph.getConfiguration().getString(JDBC_URL) + TABLES_HAZELCAST_MAP);
         tableMapConfig.setNearCacheConfig(nearCacheConfig);
         config.addMapConfig(tableMapConfig);
 
         MapConfig edgeForeignKeysMapConfig = new MapConfig();
-        edgeForeignKeysMapConfig.setName(this.sqlgGraph.getConfiguration().getString("jdbc.url") + EDGE_FOREIGN_KEYS_HAZELCAST_MAP);
+        edgeForeignKeysMapConfig.setName(this.sqlgGraph.getConfiguration().getString(JDBC_URL) + EDGE_FOREIGN_KEYS_HAZELCAST_MAP);
         edgeForeignKeysMapConfig.setNearCacheConfig(nearCacheConfig);
         config.addMapConfig(edgeForeignKeysMapConfig);
 
         MapConfig tableLabelMapConfig = new MapConfig();
-        tableLabelMapConfig.setName(this.sqlgGraph.getConfiguration().getString("jdbc.url") + TABLE_LABELS_HAZELCAST_MAP);
+        tableLabelMapConfig.setName(this.sqlgGraph.getConfiguration().getString(JDBC_URL) + TABLE_LABELS_HAZELCAST_MAP);
         tableLabelMapConfig.setNearCacheConfig(nearCacheConfig);
         config.addMapConfig(tableLabelMapConfig);
         return config;
@@ -337,8 +343,8 @@ public class SchemaManager {
     }
 
     void ensureVertexTableExist(final String schema, final String table, final Object... keyValues) {
-        Objects.requireNonNull(schema, "Given tables must not be null");
-        Objects.requireNonNull(table, "Given table must not be null");
+        Objects.requireNonNull(schema, GIVEN_TABLES_MUST_NOT_BE_NULL);
+        Objects.requireNonNull(table, GIVEN_TABLE_MUST_NOT_BE_NULL);
         final String prefixedTable = VERTEX_PREFIX + table;
         final ConcurrentHashMap<String, PropertyType> columns = SqlgUtil.transformToColumnDefinitionMap(keyValues);
         if (!this.localTables.containsKey(schema + "." + prefixedTable)) {
@@ -375,8 +381,8 @@ public class SchemaManager {
     }
 
     void ensureVertexTemporaryTableExist(final String schema, final String table, final Object... keyValues) {
-        Objects.requireNonNull(schema, "Given tables must not be null");
-        Objects.requireNonNull(table, "Given table must not be null");
+        Objects.requireNonNull(schema, GIVEN_TABLES_MUST_NOT_BE_NULL);
+        Objects.requireNonNull(table, GIVEN_TABLE_MUST_NOT_BE_NULL);
         final String prefixedTable = VERTEX_PREFIX + table;
         final ConcurrentHashMap<String, PropertyType> columns = SqlgUtil.transformToColumnDefinitionMap(keyValues);
         if (!this.localTemporaryTables.containsKey(prefixedTable)) {
@@ -417,8 +423,8 @@ public class SchemaManager {
      * @param keyValues
      */
     public void ensureEdgeTableExist(final String schema, final String table, final SchemaTable foreignKeyIn, final SchemaTable foreignKeyOut, Object... keyValues) {
-        Objects.requireNonNull(schema, "Given tables must not be null");
-        Objects.requireNonNull(table, "Given table must not be null");
+        Objects.requireNonNull(schema, GIVEN_TABLES_MUST_NOT_BE_NULL);
+        Objects.requireNonNull(table, GIVEN_TABLE_MUST_NOT_BE_NULL);
         Objects.requireNonNull(foreignKeyIn.getSchema(), "Given inTable must not be null");
         Objects.requireNonNull(foreignKeyOut.getTable(), "Given outTable must not be null");
         final String prefixedTable = EDGE_PREFIX + table;
@@ -487,8 +493,8 @@ public class SchemaManager {
      * @param keyValues
      */
     public void ensureEdgeTableExist(final String schema, final String table, Object... keyValues) {
-        Objects.requireNonNull(schema, "Given tables must not be null");
-        Objects.requireNonNull(table, "Given table must not be null");
+        Objects.requireNonNull(schema, GIVEN_TABLES_MUST_NOT_BE_NULL);
+        Objects.requireNonNull(table, GIVEN_TABLE_MUST_NOT_BE_NULL);
         final String prefixedTable = EDGE_PREFIX + table;
         final ConcurrentHashMap<String, PropertyType> columns = SqlgUtil.transformToColumnDefinitionMap(keyValues);
         if (!this.localTables.containsKey(schema + "." + prefixedTable)) {
@@ -1182,20 +1188,20 @@ public class SchemaManager {
 
         Map<String, PropertyType> columns = new HashedMap<>();
         columns.put("name", PropertyType.STRING);
-        columns.put("createdOn", PropertyType.LOCALDATETIME);
+        columns.put(CREATED_ON, PropertyType.LOCALDATETIME);
         this.localTables.put(SQLG_SCHEMA + "." + VERTEX_PREFIX + SQLG_SCHEMA_SCHEMA, columns);
         columns = new HashedMap<>();
         columns.put("name", PropertyType.STRING);
         columns.put("schemaVertex", PropertyType.STRING);
-        columns.put("createdOn", PropertyType.LOCALDATETIME);
+        columns.put(CREATED_ON, PropertyType.LOCALDATETIME);
         this.localTables.put(SQLG_SCHEMA + "." + VERTEX_PREFIX + SQLG_SCHEMA_VERTEX_LABEL, columns);
         columns = new HashedMap<>();
         columns.put("name", PropertyType.STRING);
-        columns.put("createdOn", PropertyType.LOCALDATETIME);
+        columns.put(CREATED_ON, PropertyType.LOCALDATETIME);
         this.localTables.put(SQLG_SCHEMA + "." + VERTEX_PREFIX + SQLG_SCHEMA_EDGE_LABEL, columns);
         columns = new HashedMap<>();
         columns.put("name", PropertyType.STRING);
-        columns.put("createdOn", PropertyType.LOCALDATETIME);
+        columns.put(CREATED_ON, PropertyType.LOCALDATETIME);
         columns.put("type", PropertyType.STRING);
         this.localTables.put(SQLG_SCHEMA + "." + VERTEX_PREFIX + SQLG_SCHEMA_PROPERTY, columns);
 
@@ -1335,7 +1341,7 @@ public class SchemaManager {
         this.sqlgGraph.addVertex(
                 T.label, SQLG_SCHEMA + "." + SQLG_SCHEMA_SCHEMA,
                 "name", this.sqlDialect.getPublicSchema(),
-                "createdOn", LocalDateTime.now()
+                CREATED_ON, LocalDateTime.now()
         );
     }
 
@@ -1550,17 +1556,17 @@ public class SchemaManager {
 
         @Override
         public void entryEvicted(EntryEvent<String, String> event) {
-            throw new IllegalStateException("Should not happen!");
+            throw new IllegalStateException(SHOULD_NOT_HAPPEN);
         }
 
         @Override
         public void mapEvicted(MapEvent event) {
-            throw new IllegalStateException("Should not happen!");
+            throw new IllegalStateException(SHOULD_NOT_HAPPEN);
         }
 
         @Override
         public void mapCleared(MapEvent event) {
-            throw new IllegalStateException("Should not happen!");
+            throw new IllegalStateException(SHOULD_NOT_HAPPEN);
         }
     }
 
@@ -1588,17 +1594,17 @@ public class SchemaManager {
 
         @Override
         public void entryEvicted(EntryEvent<String, Set<String>> event) {
-            throw new IllegalStateException("Should not happen!");
+            throw new IllegalStateException(SHOULD_NOT_HAPPEN);
         }
 
         @Override
         public void mapEvicted(MapEvent event) {
-            throw new IllegalStateException("Should not happen!");
+            throw new IllegalStateException(SHOULD_NOT_HAPPEN);
         }
 
         @Override
         public void mapCleared(MapEvent event) {
-            throw new IllegalStateException("Should not happen!");
+            throw new IllegalStateException(SHOULD_NOT_HAPPEN);
         }
     }
 
@@ -1626,17 +1632,17 @@ public class SchemaManager {
 
         @Override
         public void entryEvicted(EntryEvent<String, Map<String, PropertyType>> event) {
-            throw new IllegalStateException("Should not happen!");
+            throw new IllegalStateException(SHOULD_NOT_HAPPEN);
         }
 
         @Override
         public void mapEvicted(MapEvent event) {
-            throw new IllegalStateException("Should not happen!");
+            throw new IllegalStateException(SHOULD_NOT_HAPPEN);
         }
 
         @Override
         public void mapCleared(MapEvent event) {
-            throw new IllegalStateException("Should not happen!");
+            throw new IllegalStateException(SHOULD_NOT_HAPPEN);
         }
     }
 
@@ -1664,17 +1670,17 @@ public class SchemaManager {
 
         @Override
         public void entryEvicted(EntryEvent<String, Set<String>> event) {
-            throw new IllegalStateException("Should not happen!");
+            throw new IllegalStateException(SHOULD_NOT_HAPPEN);
         }
 
         @Override
         public void mapEvicted(MapEvent event) {
-            throw new IllegalStateException("Should not happen!");
+            throw new IllegalStateException(SHOULD_NOT_HAPPEN);
         }
 
         @Override
         public void mapCleared(MapEvent event) {
-            throw new IllegalStateException("Should not happen!");
+            throw new IllegalStateException(SHOULD_NOT_HAPPEN);
         }
     }
 
@@ -1702,17 +1708,17 @@ public class SchemaManager {
 
         @Override
         public void entryEvicted(EntryEvent<SchemaTable, Pair<Set<SchemaTable>, Set<SchemaTable>>> event) {
-            throw new IllegalStateException("Should not happen!");
+            throw new IllegalStateException(SHOULD_NOT_HAPPEN);
         }
 
         @Override
         public void mapEvicted(MapEvent event) {
-            throw new IllegalStateException("Should not happen!");
+            throw new IllegalStateException(SHOULD_NOT_HAPPEN);
         }
 
         @Override
         public void mapCleared(MapEvent event) {
-            throw new IllegalStateException("Should not happen!");
+            throw new IllegalStateException(SHOULD_NOT_HAPPEN);
         }
     }
 

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgDataSource.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgDataSource.java
@@ -18,6 +18,7 @@ import java.util.*;
  */
 public class SqlgDataSource {
 
+    public static final String JDBC_URL = "jdbc.url";
     private static Logger logger = LoggerFactory.getLogger(SqlgGraph.class.getName());
     private Map<String, ComboPooledDataSource> cpdss = new HashMap<>();
 
@@ -30,10 +31,10 @@ public class SqlgDataSource {
 
     public static SqlgDataSource setupDataSource(String driver, final Configuration configuration) throws PropertyVetoException {
         SqlgDataSource ds = new SqlgDataSource();
-        Preconditions.checkState(configuration.containsKey("jdbc.url"));
+        Preconditions.checkState(configuration.containsKey(JDBC_URL));
         Preconditions.checkState(configuration.containsKey("jdbc.username"));
         Preconditions.checkState(configuration.containsKey("jdbc.password"));
-        String connectURI = configuration.getString("jdbc.url");
+        String connectURI = configuration.getString(JDBC_URL);
         String username = configuration.getString("jdbc.username");
         String password = configuration.getString("jdbc.password");
 
@@ -41,7 +42,7 @@ public class SqlgDataSource {
             return ds;
         }
         //this odd logic is for travis, it needs log feedback to not kill the build
-        if (configuration.getString("jdbc.url").contains("postgresql")) {
+        if (configuration.getString(JDBC_URL).contains("postgresql")) {
             logger.info(String.format("Setting up datasource to %s for user %s", connectURI, username));
         } else {
             logger.debug(String.format("Setting up datasource to %s for user %s", connectURI, username));

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgEdge.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgEdge.java
@@ -20,6 +20,7 @@ import java.util.*;
  */
 public class SqlgEdge extends SqlgElement implements Edge {
 
+    public static final String IN_OR_OUT_VERTEX_ID_NOT_SET = "in or out vertex id not set!!!!";
     private Logger logger = LoggerFactory.getLogger(SqlgEdge.class.getName());
     private SqlgVertex inVertex;
     private SqlgVertex outVertex;
@@ -281,7 +282,7 @@ public class SqlgEdge extends SqlgElement implements Edge {
             }
         }
         if (this.inVertex == null || this.outVertex == null) {
-            throw new IllegalStateException("in or out vertex id not set!!!!");
+            throw new IllegalStateException(IN_OR_OUT_VERTEX_ID_NOT_SET);
         }
     }
 
@@ -320,7 +321,7 @@ public class SqlgEdge extends SqlgElement implements Edge {
             }
         }
         if (this.inVertex == null || this.outVertex == null) {
-            throw new IllegalStateException("in or out vertex id not set!!!!");
+            throw new IllegalStateException(IN_OR_OUT_VERTEX_ID_NOT_SET);
         }
     }
 
@@ -349,7 +350,7 @@ public class SqlgEdge extends SqlgElement implements Edge {
             }
         }
         if (inVertexColumnName == null || outVertexColumnName == null) {
-            throw new IllegalStateException("in or out vertex id not set!!!!");
+            throw new IllegalStateException(IN_OR_OUT_VERTEX_ID_NOT_SET);
         }
         Long inId = resultSet.getLong(inVertexColumnName.getSchema() + "." + inVertexColumnName.getTable());
         Long outId = resultSet.getLong(outVertexColumnName.getSchema() + "." + outVertexColumnName.getTable());

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgElement.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgElement.java
@@ -33,6 +33,7 @@ import java.util.stream.Stream;
  */
 public abstract class SqlgElement implements Element {
 
+    public static final String PROPERTY_ARRAY_VALUE_ELEMENTS_NOT_NULL = "Property array value elements may not be null.";
     private Logger logger = LoggerFactory.getLogger(SqlgVertex.class.getName());
 
     protected String schema;
@@ -353,7 +354,7 @@ public abstract class SqlgElement implements Element {
     private <T> T copy(Object[] value, T target) {
         for (int i = 0; i < value.length; i++) {
             if (value[i] == null) {
-                throw new IllegalArgumentException("Property array value elements may not be null.");
+                throw new IllegalArgumentException(PROPERTY_ARRAY_VALUE_ELEMENTS_NOT_NULL);
             }
             Array.set(target, i, value[i]);
         }
@@ -363,7 +364,7 @@ public abstract class SqlgElement implements Element {
     private <T> T copyToTinyInt(Integer[] value, T target) {
         for (int i = 0; i < value.length; i++) {
             if (value[i] == null) {
-                throw new IllegalArgumentException("Property array value elements may not be null.");
+                throw new IllegalArgumentException(PROPERTY_ARRAY_VALUE_ELEMENTS_NOT_NULL);
             }
             Array.set(target, i, value[i].byteValue());
         }
@@ -373,7 +374,7 @@ public abstract class SqlgElement implements Element {
     private <T> T copyToSmallInt(Object[] value, T target) {
         for (int i = 0; i < value.length; i++) {
             if (value[i] == null) {
-                throw new IllegalArgumentException("Property array value elements may not be null.");
+                throw new IllegalArgumentException(PROPERTY_ARRAY_VALUE_ELEMENTS_NOT_NULL);
             }
             Array.set(target, i, ((Number) value[i]).shortValue());
         }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgTransaction.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgTransaction.java
@@ -21,6 +21,7 @@ import java.util.Map;
  */
 public class SqlgTransaction extends AbstractThreadLocalTransaction {
 
+    public static final String BATCH_MODE_NOT_SUPPORTED = "Batch mode not supported!";
     private SqlgGraph sqlgGraph;
     private AfterCommit afterCommitFunction;
     private AfterRollback afterRollbackFunction;
@@ -135,7 +136,7 @@ public class SqlgTransaction extends AbstractThreadLocalTransaction {
             readWrite();
             threadLocalTx.get().getBatchManager().batchModeOn(BatchManager.BatchModeType.STREAMING_WITH_LOCK);
         } else {
-            throw new IllegalStateException("Batch mode not supported!");
+            throw new IllegalStateException(BATCH_MODE_NOT_SUPPORTED);
         }
     }
 
@@ -144,7 +145,7 @@ public class SqlgTransaction extends AbstractThreadLocalTransaction {
             readWrite();
             threadLocalTx.get().getBatchManager().batchModeOn(BatchManager.BatchModeType.STREAMING);
         } else {
-            throw new IllegalStateException("Batch mode not supported!");
+            throw new IllegalStateException(BATCH_MODE_NOT_SUPPORTED);
         }
     }
 
@@ -173,7 +174,7 @@ public class SqlgTransaction extends AbstractThreadLocalTransaction {
             readWrite();
             threadLocalTx.get().getBatchManager().batchModeOn(BatchManager.BatchModeType.NORMAL);
         } else {
-            throw new IllegalStateException("Batch mode not supported!");
+            throw new IllegalStateException(BATCH_MODE_NOT_SUPPORTED);
         }
     }
 

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgVertex.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgVertex.java
@@ -25,6 +25,8 @@ import java.util.*;
  */
 public class SqlgVertex extends SqlgElement implements Vertex {
 
+    public static final String WHERE = " WHERE ";
+    public static final String BUG_DIRECTION_BOTH_SHOULD_NEVER_FIRE_HERE = "BUG: Direction.BOTH should never fire here!";
     private Logger logger = LoggerFactory.getLogger(SqlgVertex.class.getName());
 
     /**
@@ -280,7 +282,7 @@ public class SqlgVertex extends SqlgElement implements Vertex {
                             sql.append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes(schemaTable.getSchema()));
                             sql.append(".");
                             sql.append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes(schemaTable.getTable()));
-                            sql.append(" WHERE ");
+                            sql.append(WHERE);
                             sql.append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes(this.schema + "." + this.table + SchemaManager.IN_VERTEX_COLUMN_END));
                             sql.append(" = ?");
                             break;
@@ -288,12 +290,12 @@ public class SqlgVertex extends SqlgElement implements Vertex {
                             sql.append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes(schemaTable.getSchema()));
                             sql.append(".");
                             sql.append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes(schemaTable.getTable()));
-                            sql.append(" WHERE ");
+                            sql.append(WHERE);
                             sql.append(this.sqlgGraph.getSchemaManager().getSqlDialect().maybeWrapInQoutes(this.schema + "." + this.table + SchemaManager.OUT_VERTEX_COLUMN_END));
                             sql.append(" = ?");
                             break;
                         case BOTH:
-                            throw new IllegalStateException("BUG: Direction.BOTH should never fire here!");
+                            throw new IllegalStateException(BUG_DIRECTION_BOTH_SHOULD_NEVER_FIRE_HERE);
                     }
                     if (this.sqlgGraph.getSqlDialect().needsSemicolon()) {
                         sql.append(";");
@@ -311,7 +313,7 @@ public class SqlgVertex extends SqlgElement implements Vertex {
                                 preparedStatement.setLong(1, this.recordId.getId());
                                 break;
                             case BOTH:
-                                throw new IllegalStateException("BUG: Direction.BOTH should never fire here!");
+                                throw new IllegalStateException(BUG_DIRECTION_BOTH_SHOULD_NEVER_FIRE_HERE);
                         }
 
                         ResultSet resultSet = preparedStatement.executeQuery();
@@ -457,7 +459,7 @@ public class SqlgVertex extends SqlgElement implements Vertex {
         sql.append(this.sqlgGraph.getSchemaManager().getSqlDialect().maybeWrapInQoutes(edgeSchemaTable.getSchema()));
         sql.append(".");
         sql.append(this.sqlgGraph.getSchemaManager().getSqlDialect().maybeWrapInQoutes(edgeSchemaTable.getTable()));
-        sql.append(" WHERE ");
+        sql.append(WHERE);
         sql.append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes(this.schema + "." + this.table + (direction == Direction.OUT ? SchemaManager.OUT_VERTEX_COLUMN_END : SchemaManager.IN_VERTEX_COLUMN_END)));
         sql.append(" = ?");
         if (this.sqlgGraph.getSqlDialect().needsSemicolon()) {
@@ -638,7 +640,7 @@ public class SqlgVertex extends SqlgElement implements Vertex {
                             tables = transformToInSchemaTables(edgeForeignKeys, hasContainerLabels);
                             break;
                         default:
-                            throw new IllegalStateException("BUG: Direction.BOTH should never fire here!");
+                            throw new IllegalStateException(BUG_DIRECTION_BOTH_SHOULD_NEVER_FIRE_HERE);
                     }
 
                     for (SchemaTable joinSchemaTable : tables) {
@@ -709,7 +711,7 @@ public class SqlgVertex extends SqlgElement implements Vertex {
 
                                 break;
                             default:
-                                throw new IllegalStateException("BUG: Direction.BOTH should never fire here!");
+                                throw new IllegalStateException(BUG_DIRECTION_BOTH_SHOULD_NEVER_FIRE_HERE);
                         }
                         if (this.sqlgGraph.getSqlDialect().needsSemicolon()) {
                             sql.append(";");
@@ -727,7 +729,7 @@ public class SqlgVertex extends SqlgElement implements Vertex {
                                     preparedStatement.setLong(1, this.recordId.getId());
                                     break;
                                 case BOTH:
-                                    throw new IllegalStateException("BUG: Direction.BOTH should never fire here!");
+                                    throw new IllegalStateException(BUG_DIRECTION_BOTH_SHOULD_NEVER_FIRE_HERE);
                             }
                             int countHasContainers = 2;
                             for (HasContainer hasContainer : hasContainers) {
@@ -911,7 +913,7 @@ public class SqlgVertex extends SqlgElement implements Vertex {
             sql.append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes(this.schema));
             sql.append(".");
             sql.append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes(SchemaManager.VERTEX_PREFIX + this.table));
-            sql.append(" WHERE ");
+            sql.append(WHERE);
             sql.append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes("ID"));
             sql.append(" = ?");
             if (this.sqlgGraph.getSqlDialect().needsSemicolon()) {

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/TopologyManager.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/TopologyManager.java
@@ -15,6 +15,12 @@ import java.util.Map;
  */
 public class TopologyManager {
 
+    public static final String CREATED_ON = "createdOn";
+    public static final String DOES_NOT_EXIST_IN_SQLG_S_TOPOLOGY_BUG = " does not exist in Sqlg's topology. BUG!!!";
+    public static final String SCHEMA = "Schema ";
+    public static final String FOUND_IN_SQLG_S_TOPOLOGY_BUG = " found in Sqlg's topology. BUG!!!";
+    public static final String MULTIPLE = "Multiple ";
+
     private TopologyManager() {}
 
     static Vertex addSchema(SqlgGraph sqlgGraph, String schema) {
@@ -23,7 +29,7 @@ public class TopologyManager {
             return sqlgGraph.addVertex(
                     T.label, SchemaManager.SQLG_SCHEMA + "." + SchemaManager.SQLG_SCHEMA_SCHEMA,
                     "name", schema,
-                    "createdOn", LocalDateTime.now()
+                    CREATED_ON, LocalDateTime.now()
             );
         } finally {
             sqlgGraph.tx().batchMode(batchModeType);
@@ -38,8 +44,8 @@ public class TopologyManager {
                     .hasLabel(SchemaManager.SQLG_SCHEMA + "." + SchemaManager.SQLG_SCHEMA_SCHEMA)
                     .has("name", schema)
                     .toList();
-            Preconditions.checkState(!schemas.isEmpty(), "Schema " + schema + " does not exist in Sqlg's topology. BUG!!!");
-            Preconditions.checkState(schemas.size() == 1, "Multiple " + schema + " found in Sqlg's topology. BUG!!!");
+            Preconditions.checkState(!schemas.isEmpty(), SCHEMA + schema + DOES_NOT_EXIST_IN_SQLG_S_TOPOLOGY_BUG);
+            Preconditions.checkState(schemas.size() == 1, MULTIPLE + schema + FOUND_IN_SQLG_S_TOPOLOGY_BUG);
             Preconditions.checkState(tableName.startsWith(SchemaManager.VERTEX_PREFIX));
             Vertex schemaVertex = schemas.get(0);
 
@@ -47,7 +53,7 @@ public class TopologyManager {
                     T.label, SchemaManager.SQLG_SCHEMA + "." + SchemaManager.SQLG_SCHEMA_VERTEX_LABEL,
                     "name", tableName.substring(SchemaManager.VERTEX_PREFIX.length()),
                     "schemaVertex", schema + tableName, //this is here for readability when in pgadmin
-                    "createdOn", LocalDateTime.now()
+                    CREATED_ON, LocalDateTime.now()
             );
             schemaVertex.addEdge(SchemaManager.SQLG_SCHEMA_SCHEMA_VERTEX_EDGE, vertex);
             for (Map.Entry<String, PropertyType> columnEntry : columns.entrySet()) {
@@ -56,7 +62,7 @@ public class TopologyManager {
                         T.label, SchemaManager.SQLG_SCHEMA + "." + SchemaManager.SQLG_SCHEMA_PROPERTY,
                         "name", columnEntry.getKey(),
                         "type", columnEntry.getValue().name(),
-                        "createdOn", LocalDateTime.now()
+                        CREATED_ON, LocalDateTime.now()
                 );
                 vertex.addEdge(SchemaManager.SQLG_SCHEMA_VERTEX_PROPERTIES_EDGE, property);
 
@@ -77,16 +83,16 @@ public class TopologyManager {
                     .hasLabel(SchemaManager.SQLG_SCHEMA + "." + SchemaManager.SQLG_SCHEMA_SCHEMA)
                     .has("name", schema)
                     .toList();
-            Preconditions.checkState(!schemas.isEmpty(), "Schema " + schema + " does not exist in Sqlg's topology. BUG!!!");
-            Preconditions.checkState(schemas.size() == 1, "Multiple " + schema + " found in Sqlg's topology. BUG!!!");
+            Preconditions.checkState(!schemas.isEmpty(), SCHEMA + schema + DOES_NOT_EXIST_IN_SQLG_S_TOPOLOGY_BUG);
+            Preconditions.checkState(schemas.size() == 1, MULTIPLE + schema + FOUND_IN_SQLG_S_TOPOLOGY_BUG);
             Vertex schemaVertex = schemas.get(0);
 
             List<Vertex> outVertices = traversalSource.V(schemaVertex)
                     .out(SchemaManager.SQLG_SCHEMA_SCHEMA_VERTEX_EDGE)
                     .has("name", foreignKeyOut.getTable())
                     .toList();
-            Preconditions.checkState(!outVertices.isEmpty(), "Out vertex " + foreignKeyOut.toString() + " does not exist in Sqlg's topology. BUG!!!");
-            Preconditions.checkState(outVertices.size() == 1, "Multiple out vertices " + foreignKeyOut.toString() + " found in Sqlg's topology. BUG!!!");
+            Preconditions.checkState(!outVertices.isEmpty(), "Out vertex " + foreignKeyOut.toString() + DOES_NOT_EXIST_IN_SQLG_S_TOPOLOGY_BUG);
+            Preconditions.checkState(outVertices.size() == 1, "Multiple out vertices " + foreignKeyOut.toString() + FOUND_IN_SQLG_S_TOPOLOGY_BUG);
             Preconditions.checkState(prefixedTable.startsWith(SchemaManager.EDGE_PREFIX));
             Vertex outVertex = outVertices.get(0);
 
@@ -95,22 +101,22 @@ public class TopologyManager {
                     .hasLabel(SchemaManager.SQLG_SCHEMA + "." + SchemaManager.SQLG_SCHEMA_SCHEMA)
                     .has("name", foreignKeyIn.getSchema())
                     .toList();
-            Preconditions.checkState(!schemas.isEmpty(), "Schema " + schema + " does not exist in Sqlg's topology. BUG!!!");
-            Preconditions.checkState(schemas.size() == 1, "Multiple " + schema + " found in Sqlg's topology. BUG!!!");
+            Preconditions.checkState(!schemas.isEmpty(), SCHEMA + schema + DOES_NOT_EXIST_IN_SQLG_S_TOPOLOGY_BUG);
+            Preconditions.checkState(schemas.size() == 1, MULTIPLE + schema + FOUND_IN_SQLG_S_TOPOLOGY_BUG);
             Vertex schemaInVertex = schemas.get(0);
 
             List<Vertex> inVertices = traversalSource.V(schemaInVertex)
                     .out(SchemaManager.SQLG_SCHEMA_SCHEMA_VERTEX_EDGE)
                     .has("name", foreignKeyIn.getTable())
                     .toList();
-            Preconditions.checkState(!inVertices.isEmpty(), "In vertex " + foreignKeyIn.toString() + " does not exist in Sqlg's topology. BUG!!!");
-            Preconditions.checkState(inVertices.size() == 1, "Multiple in vertices " + foreignKeyIn.toString() + " found in Sqlg's topology. BUG!!!");
+            Preconditions.checkState(!inVertices.isEmpty(), "In vertex " + foreignKeyIn.toString() + DOES_NOT_EXIST_IN_SQLG_S_TOPOLOGY_BUG);
+            Preconditions.checkState(inVertices.size() == 1, "Multiple in vertices " + foreignKeyIn.toString() + FOUND_IN_SQLG_S_TOPOLOGY_BUG);
             Vertex inVertex = inVertices.get(0);
 
             Vertex edgeVertex = sqlgGraph.addVertex(
                     T.label, SchemaManager.SQLG_SCHEMA + "." + SchemaManager.SQLG_SCHEMA_EDGE_LABEL,
                     "name", prefixedTable.substring(SchemaManager.EDGE_PREFIX.length()),
-                    "createdOn", LocalDateTime.now()
+                    CREATED_ON, LocalDateTime.now()
             );
 
             outVertex.addEdge(SchemaManager.SQLG_SCHEMA_OUT_EDGES_EDGE, edgeVertex);
@@ -122,7 +128,7 @@ public class TopologyManager {
                         T.label, SchemaManager.SQLG_SCHEMA + "." + SchemaManager.SQLG_SCHEMA_PROPERTY,
                         "name", columnEntry.getKey(),
                         "type", columnEntry.getValue().name(),
-                        "createdOn", LocalDateTime.now()
+                        CREATED_ON, LocalDateTime.now()
                 );
                 edgeVertex.addEdge(SchemaManager.SQLG_SCHEMA_EDGE_PROPERTIES_EDGE, property);
 
@@ -141,8 +147,8 @@ public class TopologyManager {
                     .hasLabel(SchemaManager.SQLG_SCHEMA + "." + SchemaManager.SQLG_SCHEMA_SCHEMA)
                     .has("name", schema)
                     .toList();
-            Preconditions.checkState(!schemas.isEmpty(), "Schema " + schema + " does not exist in Sqlg's topology. BUG!!!");
-            Preconditions.checkState(schemas.size() == 1, "Multiple " + schema + " found in Sqlg's topology. BUG!!!");
+            Preconditions.checkState(!schemas.isEmpty(), SCHEMA + schema + DOES_NOT_EXIST_IN_SQLG_S_TOPOLOGY_BUG);
+            Preconditions.checkState(schemas.size() == 1, MULTIPLE + schema + FOUND_IN_SQLG_S_TOPOLOGY_BUG);
             Vertex schemaVertex = schemas.get(0);
 
             Preconditions.checkState(prefixedTable.startsWith(SchemaManager.EDGE_PREFIX));
@@ -155,8 +161,8 @@ public class TopologyManager {
                     .<Vertex>select("a")
                     .dedup()
                     .toList();
-            Preconditions.checkState(!edgeVertices.isEmpty(), "Edge vertex " + foreignKey.toString() + " does not exist in Sqlg's topology. BUG!!!");
-            Preconditions.checkState(edgeVertices.size() == 1, "Multiple edge vertices " + foreignKey.toString() + " found in Sqlg's topology. BUG!!!");
+            Preconditions.checkState(!edgeVertices.isEmpty(), "Edge vertex " + foreignKey.toString() + DOES_NOT_EXIST_IN_SQLG_S_TOPOLOGY_BUG);
+            Preconditions.checkState(edgeVertices.size() == 1, "Multiple edge vertices " + foreignKey.toString() + FOUND_IN_SQLG_S_TOPOLOGY_BUG);
             Vertex edgeVertex = edgeVertices.get(0);
 
             String vertexTable;
@@ -169,8 +175,8 @@ public class TopologyManager {
                     .out(SchemaManager.SQLG_SCHEMA_SCHEMA_VERTEX_EDGE)
                     .has("name", vertexTable)
                     .toList();
-            Preconditions.checkState(!foreignKeyVertices.isEmpty(), "Out vertex " + foreignKey.toString() + " does not exist in Sqlg's topology. BUG!!!");
-            Preconditions.checkState(foreignKeyVertices.size() == 1, "Multiple out vertices " + foreignKey.toString() + " found in Sqlg's topology. BUG!!!");
+            Preconditions.checkState(!foreignKeyVertices.isEmpty(), "Out vertex " + foreignKey.toString() + DOES_NOT_EXIST_IN_SQLG_S_TOPOLOGY_BUG);
+            Preconditions.checkState(foreignKeyVertices.size() == 1, "Multiple out vertices " + foreignKey.toString() + FOUND_IN_SQLG_S_TOPOLOGY_BUG);
             Preconditions.checkState(prefixedTable.startsWith(SchemaManager.EDGE_PREFIX));
             Vertex foreignKeyVertex = foreignKeyVertices.get(0);
 
@@ -211,7 +217,7 @@ public class TopologyManager {
                     T.label, SchemaManager.SQLG_SCHEMA + "." + SchemaManager.SQLG_SCHEMA_PROPERTY,
                     "name", column.getKey(),
                     "type", column.getValue().name(),
-                    "createdOn", LocalDateTime.now()
+                    CREATED_ON, LocalDateTime.now()
             );
             vertex.addEdge(SchemaManager.SQLG_SCHEMA_VERTEX_PROPERTIES_EDGE, property);
 
@@ -255,7 +261,7 @@ public class TopologyManager {
                     T.label, SchemaManager.SQLG_SCHEMA + "." + SchemaManager.SQLG_SCHEMA_PROPERTY,
                     "name", column.getKey(),
                     "type", column.getValue().name(),
-                    "createdOn", LocalDateTime.now()
+                    CREATED_ON, LocalDateTime.now()
             );
             edge.addEdge(SchemaManager.SQLG_SCHEMA_EDGE_PROPERTIES_EDGE, property);
         } finally {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1192 - String literals should not be duplicated.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
Please let me know if you have any questions.
George Kankava