### PR TITLE
squid:S2864 - entrySet should be iterated when both the key and value are needed

### DIFF
--- a/sqlg-core/src/main/java/org/umlg/sqlg/sql/parse/SchemaTableTree.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/sql/parse/SchemaTableTree.java
@@ -536,11 +536,11 @@ public class SchemaTableTree {
             sql += ", ";
         }
         int propertyCount = 1;
-        for (String propertyName : propertyTypeMap.keySet()) {
-            sql += "a" + count + ".\"" + this.mappedAliasPropertyName(propertyName) + "\"";
-            for (String postFix : propertyTypeMap.get(propertyName).getPostFixes()) {
+        for (Map.Entry<String, PropertyType> propertyNameEntry : propertyTypeMap.entrySet()) {
+            sql += "a" + count + ".\"" + this.mappedAliasPropertyName(propertyNameEntry.getKey()) + "\"";
+            for (String postFix : propertyNameEntry.getValue().getPostFixes()) {
                 sql += ", ";
-                sql += "a" + count + ".\"" + this.mappedAliasPropertyName(propertyName + postFix) + "\"";
+                sql += "a" + count + ".\"" + this.mappedAliasPropertyName(propertyNameEntry.getKey() + postFix) + "\"";
             }
             if (propertyCount++ < propertyTypeMap.size()) {
                 sql += ", ";
@@ -1264,15 +1264,15 @@ public class SchemaTableTree {
         finalFromSchemaTableName += ".";
         finalFromSchemaTableName += sqlgGraph.getSqlDialect().maybeWrapInQoutes(lastSchemaTableTree.getSchemaTable().getTable());
         int propertyCount = 1;
-        for (String propertyName : propertyTypeMap.keySet()) {
-            sql += finalFromSchemaTableName + "." + sqlgGraph.getSqlDialect().maybeWrapInQoutes(propertyName);
+        for (Map.Entry<String, PropertyType> propertyTypeMapEntry : propertyTypeMap.entrySet()) {
+            sql += finalFromSchemaTableName + "." + sqlgGraph.getSqlDialect().maybeWrapInQoutes(propertyTypeMapEntry.getKey());
             sql += " AS ";
-            sql += sqlgGraph.getSqlDialect().maybeWrapInQoutes(lastSchemaTableTree.calculateAliasPropertyName(propertyName));
-            for (String postFix : propertyTypeMap.get(propertyName).getPostFixes()) {
+            sql += sqlgGraph.getSqlDialect().maybeWrapInQoutes(lastSchemaTableTree.calculateAliasPropertyName(propertyTypeMapEntry.getKey()));
+            for (String postFix : propertyTypeMapEntry.getValue().getPostFixes()) {
                 sql += ", ";
-                sql += finalFromSchemaTableName + "." + sqlgGraph.getSqlDialect().maybeWrapInQoutes(propertyName + postFix);
+                sql += finalFromSchemaTableName + "." + sqlgGraph.getSqlDialect().maybeWrapInQoutes(propertyTypeMapEntry.getKey() + postFix);
                 sql += " AS ";
-                sql += sqlgGraph.getSqlDialect().maybeWrapInQoutes(lastSchemaTableTree.calculateAliasPropertyName(propertyName + postFix));
+                sql += sqlgGraph.getSqlDialect().maybeWrapInQoutes(lastSchemaTableTree.calculateAliasPropertyName(propertyTypeMapEntry.getKey() + postFix));
             }
             if (propertyCount++ < propertyTypeMap.size()) {
                 sql += ",\n\t";
@@ -1313,16 +1313,16 @@ public class SchemaTableTree {
         finalFromSchemaTableName += ".";
         finalFromSchemaTableName += sqlgGraph.getSqlDialect().maybeWrapInQoutes(lastSchemaTableTree.getSchemaTable().getTable());
         int count = 1;
-        for (String propertyName : propertyTypeMap.keySet()) {
-            sql += finalFromSchemaTableName + "." + sqlgGraph.getSqlDialect().maybeWrapInQoutes(propertyName);
+        for (Map.Entry<String, PropertyType> propertyTypeMapEntry : propertyTypeMap.entrySet()) {
+            sql += finalFromSchemaTableName + "." + sqlgGraph.getSqlDialect().maybeWrapInQoutes(propertyTypeMapEntry.getKey());
             sql += " AS ";
-            sql += sqlgGraph.getSqlDialect().maybeWrapInQoutes(lastSchemaTableTree.calculateLabeledAliasPropertyName(propertyName));
+            sql += sqlgGraph.getSqlDialect().maybeWrapInQoutes(lastSchemaTableTree.calculateLabeledAliasPropertyName(propertyTypeMapEntry.getKey()));
 
-            for (String postFix : propertyTypeMap.get(propertyName).getPostFixes()) {
+            for (String postFix : propertyTypeMapEntry.getValue().getPostFixes()) {
                 sql += ",\n\t ";
-                sql += finalFromSchemaTableName + "." + sqlgGraph.getSqlDialect().maybeWrapInQoutes(propertyName + postFix);
+                sql += finalFromSchemaTableName + "." + sqlgGraph.getSqlDialect().maybeWrapInQoutes(propertyTypeMapEntry.getKey() + postFix);
                 sql += " AS ";
-                sql += sqlgGraph.getSqlDialect().maybeWrapInQoutes(lastSchemaTableTree.calculateAliasPropertyName(propertyName + postFix));
+                sql += sqlgGraph.getSqlDialect().maybeWrapInQoutes(lastSchemaTableTree.calculateAliasPropertyName(propertyTypeMapEntry.getKey() + postFix));
             }
 
             if (count++ < propertyTypeMap.size()) {

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SchemaManager.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SchemaManager.java
@@ -174,44 +174,44 @@ public class SchemaManager {
                     }
                     this.localSchemas.put(schema, schema);
                 }
-                for (String table : this.uncommittedTables.keySet()) {
+                for (Map.Entry<String, Map<String, PropertyType>> uncommittedTablesEntry : this.uncommittedTables.entrySet()) {
                     if (distributed) {
-                        this.tables.put(table, this.uncommittedTables.get(table));
+                        this.tables.put(uncommittedTablesEntry.getKey(), uncommittedTablesEntry.getValue());
                     }
-                    this.localTables.put(table, this.uncommittedTables.get(table));
+                    this.localTables.put(uncommittedTablesEntry.getKey(), uncommittedTablesEntry.getValue());
                 }
-                for (String table : this.uncommittedLabelSchemas.keySet()) {
-                    Set<String> schemas = this.localLabelSchemas.get(table);
+                for (Map.Entry<String, Set<String>> uncommittedLabelSchemasEntry : this.uncommittedLabelSchemas.entrySet()) {
+                    Set<String> schemas = uncommittedLabelSchemasEntry.getValue();
                     if (schemas == null) {
                         if (distributed) {
-                            this.labelSchemas.put(table, this.uncommittedLabelSchemas.get(table));
+                            this.labelSchemas.put(uncommittedLabelSchemasEntry.getKey(), uncommittedLabelSchemasEntry.getValue());
                         }
-                        this.localLabelSchemas.put(table, this.uncommittedLabelSchemas.get(table));
+                        this.localLabelSchemas.put(uncommittedLabelSchemasEntry.getKey(), this.uncommittedLabelSchemas.get(uncommittedLabelSchemasEntry.getKey()));
                     } else {
-                        schemas.addAll(this.uncommittedLabelSchemas.get(table));
+                        schemas.addAll(this.uncommittedLabelSchemas.get(uncommittedLabelSchemasEntry.getKey()));
                         if (distributed) {
-                            this.labelSchemas.put(table, schemas);
+                            this.labelSchemas.put(uncommittedLabelSchemasEntry.getKey(), schemas);
                         }
-                        this.localLabelSchemas.put(table, schemas);
+                        this.localLabelSchemas.put(uncommittedLabelSchemasEntry.getKey(), schemas);
                     }
                 }
-                for (String table : this.uncommittedEdgeForeignKeys.keySet()) {
+                for (Map.Entry<String, Set<String>> uncommittedEdgeForeignKeysEntry : this.uncommittedEdgeForeignKeys.entrySet()) {
                     if (distributed) {
-                        this.edgeForeignKeys.put(table, this.uncommittedEdgeForeignKeys.get(table));
+                        this.edgeForeignKeys.put(uncommittedEdgeForeignKeysEntry.getKey(), uncommittedEdgeForeignKeysEntry.getValue());
                     }
-                    this.localEdgeForeignKeys.put(table, this.uncommittedEdgeForeignKeys.get(table));
+                    this.localEdgeForeignKeys.put(uncommittedEdgeForeignKeysEntry.getKey(), uncommittedEdgeForeignKeysEntry.getValue());
                 }
-                for (SchemaTable schemaTable : this.uncommittedTableLabels.keySet()) {
-                    Pair<Set<SchemaTable>, Set<SchemaTable>> tableLabels = this.localTableLabels.get(schemaTable);
+                for (Map.Entry<SchemaTable, Pair<Set<SchemaTable>, Set<SchemaTable>>> schemaTableEntry : this.uncommittedTableLabels.entrySet()) {
+                    Pair<Set<SchemaTable>, Set<SchemaTable>> tableLabels = schemaTableEntry.getValue();
                     if (tableLabels == null) {
                         tableLabels = Pair.of(new HashSet<>(), new HashSet<>());
                     }
-                    tableLabels.getLeft().addAll(this.uncommittedTableLabels.get(schemaTable).getLeft());
-                    tableLabels.getRight().addAll(this.uncommittedTableLabels.get(schemaTable).getRight());
+                    tableLabels.getLeft().addAll(schemaTableEntry.getValue().getLeft());
+                    tableLabels.getRight().addAll(schemaTableEntry.getValue().getRight());
                     if (distributed) {
-                        this.tableLabels.put(schemaTable, tableLabels);
+                        this.tableLabels.put(schemaTableEntry.getKey(), tableLabels);
                     }
-                    this.localTableLabels.put(schemaTable, tableLabels);
+                    this.localTableLabels.put(schemaTableEntry.getKey(), tableLabels);
                 }
                 this.uncommittedSchemas.clear();
                 this.uncommittedTables.clear();
@@ -237,44 +237,44 @@ public class SchemaManager {
                         }
                         this.localSchemas.put(table, table);
                     }
-                    for (String table : this.uncommittedTables.keySet()) {
+                    for (Map.Entry<String, Map<String, PropertyType>> tableEntry : this.uncommittedTables.entrySet()) {
                         if (distributed) {
-                            this.tables.put(table, this.uncommittedTables.get(table));
+                            this.tables.put(tableEntry.getKey(), tableEntry.getValue());
                         }
-                        this.localTables.put(table, this.uncommittedTables.get(table));
+                        this.localTables.put(tableEntry.getKey(), tableEntry.getValue());
                     }
-                    for (String table : this.uncommittedLabelSchemas.keySet()) {
-                        Set<String> schemas = this.localLabelSchemas.get(table);
+                    for (Map.Entry<String, Set<String>> tableEntry : this.uncommittedLabelSchemas.entrySet()) {
+                        Set<String> schemas = tableEntry.getValue();
                         if (schemas == null) {
                             if (distributed) {
-                                this.labelSchemas.put(table, this.uncommittedLabelSchemas.get(table));
+                                this.labelSchemas.put(tableEntry.getKey(), tableEntry.getValue());
                             }
-                            this.localLabelSchemas.put(table, this.uncommittedLabelSchemas.get(table));
+                            this.localLabelSchemas.put(tableEntry.getKey(), tableEntry.getValue());
                         } else {
-                            schemas.addAll(this.uncommittedLabelSchemas.get(table));
+                            schemas.addAll(tableEntry.getValue());
                             if (distributed) {
-                                this.labelSchemas.put(table, schemas);
+                                this.labelSchemas.put(tableEntry.getKey(), schemas);
                             }
-                            this.localLabelSchemas.put(table, schemas);
+                            this.localLabelSchemas.put(tableEntry.getKey(), schemas);
                         }
                     }
-                    for (String table : this.uncommittedEdgeForeignKeys.keySet()) {
+                    for (Map.Entry<String, Set<String>> tableEntry : this.uncommittedEdgeForeignKeys.entrySet()) {
                         if (distributed) {
-                            this.edgeForeignKeys.put(table, this.uncommittedEdgeForeignKeys.get(table));
+                            this.edgeForeignKeys.put(tableEntry.getKey(), tableEntry.getValue());
                         }
-                        this.localEdgeForeignKeys.put(table, this.uncommittedEdgeForeignKeys.get(table));
+                        this.localEdgeForeignKeys.put(tableEntry.getKey(), tableEntry.getValue());
                     }
-                    for (SchemaTable schemaTable : this.uncommittedTableLabels.keySet()) {
-                        Pair<Set<SchemaTable>, Set<SchemaTable>> tableLabels = this.localTableLabels.get(schemaTable);
+                    for (Map.Entry<SchemaTable, Pair<Set<SchemaTable>, Set<SchemaTable>>> schemaTableEntry : this.uncommittedTableLabels.entrySet()) {
+                        Pair<Set<SchemaTable>, Set<SchemaTable>> tableLabels = schemaTableEntry.getValue();
                         if (tableLabels == null) {
                             tableLabels = Pair.of(new HashSet<>(), new HashSet<>());
                         }
-                        tableLabels.getLeft().addAll(this.uncommittedTableLabels.get(schemaTable).getLeft());
-                        tableLabels.getRight().addAll(this.uncommittedTableLabels.get(schemaTable).getRight());
+                        tableLabels.getLeft().addAll(schemaTableEntry.getValue().getLeft());
+                        tableLabels.getRight().addAll(schemaTableEntry.getValue().getRight());
                         if (distributed) {
-                            this.tableLabels.put(schemaTable, tableLabels);
+                            this.tableLabels.put(schemaTableEntry.getKey(), tableLabels);
                         }
-                        this.localTableLabels.put(schemaTable, tableLabels);
+                        this.localTableLabels.put(schemaTableEntry.getKey(), tableLabels);
                     }
                     this.uncommittedSchemas.clear();
                     this.uncommittedTables.clear();
@@ -1421,14 +1421,14 @@ public class SchemaManager {
         result.putAll(this.localEdgeForeignKeys);
         if (!this.uncommittedEdgeForeignKeys.isEmpty() && this.isLockedByCurrentThread()) {
             result.putAll(this.uncommittedEdgeForeignKeys);
-            for (String schemaTable : this.uncommittedEdgeForeignKeys.keySet()) {
-                Set<String> foreignKeys = result.get(schemaTable);
+            for (Map.Entry<String, Set<String>> schemaTableEntry : this.uncommittedEdgeForeignKeys.entrySet()) {
+                Set<String> foreignKeys = result.get(schemaTableEntry.getKey());
                 if (foreignKeys == null) {
                     foreignKeys = new HashSet<>();
                 }
-                foreignKeys.addAll(this.uncommittedEdgeForeignKeys.get(schemaTable));
-                foreignKeys.addAll(this.uncommittedEdgeForeignKeys.get(schemaTable));
-                result.put(schemaTable, foreignKeys);
+                foreignKeys.addAll(schemaTableEntry.getValue());
+                foreignKeys.addAll(schemaTableEntry.getValue());
+                result.put(schemaTableEntry.getKey(), foreignKeys);
             }
         }
         return Collections.unmodifiableMap(result);

--- a/sqlg-core/src/main/java/org/umlg/sqlg/util/SqlgUtil.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/util/SqlgUtil.java
@@ -362,9 +362,9 @@ public class SqlgUtil {
     public static Object[] mapTokeyValues(Map<Object, Object> keyValues) {
         Object[] result = new Object[keyValues.size() * 2];
         int i = 0;
-        for (Object key : keyValues.keySet()) {
-            result[i++] = key;
-            result[i++] = keyValues.get(key);
+        for (Map.Entry<Object, Object> entry : keyValues.entrySet()) {
+            result[i++] = entry.getKey();
+            result[i++] = entry.getValue();
         }
         return result;
     }
@@ -372,9 +372,9 @@ public class SqlgUtil {
     public static Object[] mapToStringKeyValues(Map<String, Object> keyValues) {
         Object[] result = new Object[keyValues.size() * 2];
         int i = 0;
-        for (Object key : keyValues.keySet()) {
-            result[i++] = key;
-            result[i++] = keyValues.get(key);
+        for (Map.Entry<String, Object> entry : keyValues.entrySet()) {
+            result[i++] = entry.getKey();
+            result[i++] = entry.getValue();
         }
         return result;
     }
@@ -451,11 +451,11 @@ public class SqlgUtil {
 
     public static List<ImmutablePair<PropertyType, Object>> transformToTypeAndValue(Map<String, Object> keyValues) {
         List<ImmutablePair<PropertyType, Object>> result = new ArrayList<>();
-        for (String key : keyValues.keySet()) {
-            Object value = keyValues.get(key);
+        for (Map.Entry<String, Object> entry : keyValues.entrySet()) {
+            Object value = entry.getValue();
             //value
             //skip the label as that is not a property but the table
-            if (key.equals(T.label)) {
+            if (entry.getKey().equals(T.label)) {
                 continue;
             }
             result.add(ImmutablePair.of(PropertyType.from(value), value));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2864 - entrySet should be iterated when both the key and value are needed.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2864
Please let me know if you have any questions.
George Kankava