### PR TITLE
squid:S2160 - Subclasses that add fields should override equals

### DIFF
--- a/sqlg-core/src/main/java/org/umlg/sqlg/strategy/BaseSqlgStrategy.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/strategy/BaseSqlgStrategy.java
@@ -528,4 +528,25 @@ public abstract class BaseSqlgStrategy extends AbstractTraversalStrategy<Travers
 
     private class UnoptimizableException extends RuntimeException {
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        BaseSqlgStrategy that = (BaseSqlgStrategy) o;
+
+        if (sqlgGraph != null ? !sqlgGraph.equals(that.sqlgGraph) : that.sqlgGraph != null) return false;
+        return logger != null ? logger.equals(that.logger) : that.logger == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (sqlgGraph != null ? sqlgGraph.hashCode() : 0);
+        result = 31 * result + (logger != null ? logger.hashCode() : 0);
+        return result;
+    }
 }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/strategy/SqlgGraphStepCompiled.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/strategy/SqlgGraphStepCompiled.java
@@ -158,6 +158,27 @@ public class SqlgGraphStepCompiled<S extends SqlgElement, E extends SqlgElement>
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        SqlgGraphStepCompiled<?, ?> that = (SqlgGraphStepCompiled<?, ?>) o;
+
+        if (logger != null ? !logger.equals(that.logger) : that.logger != null) return false;
+        if (replacedSteps != null ? !replacedSteps.equals(that.replacedSteps) : that.replacedSteps != null)
+            return false;
+        if (sqlgGraph != null ? !sqlgGraph.equals(that.sqlgGraph) : that.sqlgGraph != null) return false;
+        if (parsedForStrategySql != null ? !parsedForStrategySql.equals(that.parsedForStrategySql) : that.parsedForStrategySql != null)
+            return false;
+        if (iteratorSupplier != null ? !iteratorSupplier.equals(that.iteratorSupplier) : that.iteratorSupplier != null)
+            return false;
+        if (iterator != null ? !iterator.equals(that.iterator) : that.iterator != null) return false;
+        return head != null ? head.equals(that.head) : that.head == null;
+
+    }
+
+    @Override
     public int hashCode() {
         int result = super.hashCode() ^ this.returnClass.hashCode();
         for (final Object id : this.ids) {

--- a/sqlg-core/src/main/java/org/umlg/sqlg/strategy/SqlgGraphStepStrategy.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/strategy/SqlgGraphStepStrategy.java
@@ -118,5 +118,24 @@ public class SqlgGraphStepStrategy extends BaseSqlgStrategy {
             }
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        SqlgGraphStepStrategy that = (SqlgGraphStepStrategy) o;
+
+        return logger != null ? logger.equals(that.logger) : that.logger == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (logger != null ? logger.hashCode() : 0);
+        return result;
+    }
 }
 

--- a/sqlg-core/src/main/java/org/umlg/sqlg/strategy/SqlgOrderGlobalStep.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/strategy/SqlgOrderGlobalStep.java
@@ -61,6 +61,23 @@ public class SqlgOrderGlobalStep<S, C extends Comparable> extends CollectingBarr
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        SqlgOrderGlobalStep<?, ?> that = (SqlgOrderGlobalStep<?, ?>) o;
+
+        if (ignore != that.ignore) return false;
+        if (chainedComparator != null ? !chainedComparator.equals(that.chainedComparator) : that.chainedComparator != null)
+            return false;
+        if (orderGlobalStep != null ? !orderGlobalStep.equals(that.orderGlobalStep) : that.orderGlobalStep != null)
+            return false;
+        return comparators != null ? comparators.equals(that.comparators) : that.comparators == null;
+
+    }
+
+    @Override
     public int hashCode() {
         int result = super.hashCode();
         for (int i = 0; i < this.comparators.size(); i++) {
@@ -109,4 +126,5 @@ public class SqlgOrderGlobalStep<S, C extends Comparable> extends CollectingBarr
             return comparators.stream().map(comparator -> new ComparatorTraverser<>(comparator)).collect(Collectors.toList());
         }
     }
+
 }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/strategy/SqlgVertexStep.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/strategy/SqlgVertexStep.java
@@ -39,4 +39,22 @@ public class SqlgVertexStep<E extends Element> extends VertexStep<E> {
         }
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        SqlgVertexStep<?> that = (SqlgVertexStep<?>) o;
+
+        return hasContainers != null ? hasContainers.equals(that.hasContainers) : that.hasContainers == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (hasContainers != null ? hasContainers.hashCode() : 0);
+        return result;
+    }
 }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/strategy/SqlgVertexStepCompiled.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/strategy/SqlgVertexStepCompiled.java
@@ -147,4 +147,29 @@ public class SqlgVertexStepCompiled<S extends SqlgElement, E extends SqlgElement
         return this.parsedForStrategySql.size() > 1 || this.parsedForStrategySql.values().stream().filter(l -> l.size() > 1).count() > 0;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        SqlgVertexStepCompiled<?, ?> that = (SqlgVertexStepCompiled<?, ?>) o;
+
+        if (head != null ? !head.equals(that.head) : that.head != null) return false;
+        if (iterator != null ? !iterator.equals(that.iterator) : that.iterator != null) return false;
+        if (replacedSteps != null ? !replacedSteps.equals(that.replacedSteps) : that.replacedSteps != null)
+            return false;
+        return parsedForStrategySql != null ? parsedForStrategySql.equals(that.parsedForStrategySql) : that.parsedForStrategySql == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (head != null ? head.hashCode() : 0);
+        result = 31 * result + (iterator != null ? iterator.hashCode() : 0);
+        result = 31 * result + (replacedSteps != null ? replacedSteps.hashCode() : 0);
+        result = 31 * result + (parsedForStrategySql != null ? parsedForStrategySql.hashCode() : 0);
+        return result;
+    }
 }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/strategy/SqlgVertexStepStrategy.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/strategy/SqlgVertexStepStrategy.java
@@ -114,4 +114,22 @@ public class SqlgVertexStepStrategy extends BaseSqlgStrategy {
         return Stream.of(SqlgGraphStepStrategy.class).collect(Collectors.toSet());
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        SqlgVertexStepStrategy that = (SqlgVertexStepStrategy) o;
+
+        return logger != null ? logger.equals(that.logger) : that.logger == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (logger != null ? logger.hashCode() : 0);
+        return result;
+    }
 }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/strategy/TopologyStrategy.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/strategy/TopologyStrategy.java
@@ -73,4 +73,25 @@ public class TopologyStrategy extends AbstractTraversalStrategy<TraversalStrateg
         }
 
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        TopologyStrategy that = (TopologyStrategy) o;
+
+        if (selectFrom != null ? !selectFrom.equals(that.selectFrom) : that.selectFrom != null) return false;
+        return selectWithout != null ? selectWithout.equals(that.selectWithout) : that.selectWithout == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (selectFrom != null ? selectFrom.hashCode() : 0);
+        result = 31 * result + (selectWithout != null ? selectWithout.hashCode() : 0);
+        return result;
+    }
 }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgEdge.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgEdge.java
@@ -374,4 +374,27 @@ public class SqlgEdge extends SqlgElement implements Edge {
     SchemaTable getSchemaTablePrefixed() {
         return SchemaTable.of(this.getSchema(), SchemaManager.EDGE_PREFIX + this.getTable());
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        SqlgEdge sqlgEdge = (SqlgEdge) o;
+
+        if (logger != null ? !logger.equals(sqlgEdge.logger) : sqlgEdge.logger != null) return false;
+        if (inVertex != null ? !inVertex.equals(sqlgEdge.inVertex) : sqlgEdge.inVertex != null) return false;
+        return outVertex != null ? outVertex.equals(sqlgEdge.outVertex) : sqlgEdge.outVertex == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (logger != null ? logger.hashCode() : 0);
+        result = 31 * result + (inVertex != null ? inVertex.hashCode() : 0);
+        result = 31 * result + (outVertex != null ? outVertex.hashCode() : 0);
+        return result;
+    }
 }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgVertex.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgVertex.java
@@ -1062,6 +1062,25 @@ public class SqlgVertex extends SqlgElement implements Vertex {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        SqlgVertex that = (SqlgVertex) o;
+
+        return logger != null ? logger.equals(that.logger) : that.logger == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (logger != null ? logger.hashCode() : 0);
+        return result;
+    }
+
+    @Override
     public String toString() {
         return StringFactory.vertexString(this);
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2160 - Subclasses that add fields should override equals.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2160
Please let me know if you have any questions.
George Kankava