### PR TITLE
squid:LowerCaseLongSuffixCheck - Long suffix L should be upper case

### DIFF
--- a/sqlg-core/src/main/java/org/umlg/sqlg/sql/dialect/SqlDialect.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/sql/dialect/SqlDialect.java
@@ -422,7 +422,7 @@ public interface SqlDialect {
     List<String> sqlgTopologyCreationScripts();
 
     default Long getPrimaryKeyStartValue() {
-        return 1l;
+        return 1L;
     }
 
     Array createArrayOf(Connection conn, PropertyType propertyType, Object[] data);

--- a/sqlg-core/src/main/java/org/umlg/sqlg/strategy/SqlgGraphStepCompiled.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/strategy/SqlgGraphStepCompiled.java
@@ -60,7 +60,7 @@ public class SqlgGraphStepCompiled<S extends SqlgElement, E extends SqlgElement>
                     //create a traverser for the first element
                     E e = (E) emit.getPath().objects().get(0);
                     if (this.isStart) {
-                        traverser = this.getTraversal().getTraverserGenerator().generate(e, this, 1l);
+                        traverser = this.getTraversal().getTraverserGenerator().generate(e, this, 1L);
                     } else {
                         traverser = this.head.split(e, this);
                     }
@@ -76,7 +76,7 @@ public class SqlgGraphStepCompiled<S extends SqlgElement, E extends SqlgElement>
                 } else {
 
                     if (this.isStart) {
-                        traverser = this.getTraversal().getTraverserGenerator().generate(element, this, 1l);
+                        traverser = this.getTraversal().getTraverserGenerator().generate(element, this, 1L);
                     } else {
                         traverser = this.head.split(element, this);
                     }

--- a/sqlg-hsqldb/src/main/java/org/umlg/sqlg/sql/dialect/HsqldbDialect.java
+++ b/sqlg-hsqldb/src/main/java/org/umlg/sqlg/sql/dialect/HsqldbDialect.java
@@ -636,7 +636,7 @@ public class HsqldbDialect extends BaseSqlDialect implements SqlDialect {
 
     @Override
     public Long getPrimaryKeyStartValue() {
-        return 0l;
+        return 0L;
     }
 
     @Override

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/TestLoadArrayProperties.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/TestLoadArrayProperties.java
@@ -44,7 +44,7 @@ public class TestLoadArrayProperties extends BaseTest {
         Assert.assertTrue(Arrays.equals(new boolean[]{true}, (boolean[])v.property("aBoolean").value()));
         Assert.assertTrue(Arrays.equals(new short[]{(short) 1}, (short[])v.property("aShort").value()));
         Assert.assertTrue(Arrays.equals(new int[]{1}, (int[])v.property("aInteger").value()));
-        Assert.assertTrue(Arrays.equals(new long[]{1l}, (long[])v.property("aLong").value()));
+        Assert.assertTrue(Arrays.equals(new long[]{1L}, (long[])v.property("aLong").value()));
         Assert.assertTrue(Arrays.equals(new float[]{1f}, (float[])v.property("aFloat").value()));
         Assert.assertTrue(Arrays.equals(new double[]{1d}, (double[])v.property("aDouble").value()));
         Assert.assertTrue(Arrays.equals(new String[]{"aaaaaaaaaaaaa"}, (String[])v.property("aString").value()));
@@ -57,7 +57,7 @@ public class TestLoadArrayProperties extends BaseTest {
         Assert.assertTrue(Arrays.equals(new boolean[]{true}, (boolean[])v.property("aBoolean").value()));
         Assert.assertTrue(Arrays.equals(new short[]{(short) 1}, (short[])v.property("aShort").value()));
         Assert.assertTrue(Arrays.equals(new int[]{1}, (int[])v.property("aInteger").value()));
-        Assert.assertTrue(Arrays.equals(new long[]{1l}, (long[])v.property("aLong").value()));
+        Assert.assertTrue(Arrays.equals(new long[]{1L}, (long[])v.property("aLong").value()));
         Assert.assertTrue(Arrays.equals(new float[]{1f}, (float[])v.property("aFloat").value()));
         Assert.assertTrue(Arrays.equals(new double[]{1d}, (double[])v.property("aDouble").value()));
         Assert.assertTrue(Arrays.equals(new String[]{"aaaaaaaaaaaaa"}, (String[])v.property("aString").value()));
@@ -89,7 +89,7 @@ public class TestLoadArrayProperties extends BaseTest {
         Assert.assertTrue(Arrays.equals(new boolean[]{true}, (boolean[])v.property("aBoolean").value()));
         Assert.assertTrue(Arrays.equals(new short[]{(short) 1}, (short[])v.property("aShort").value()));
         Assert.assertTrue(Arrays.equals(new int[]{1}, (int[])v.property("aInteger").value()));
-        Assert.assertTrue(Arrays.equals(new long[]{1l}, (long[])v.property("aLong").value()));
+        Assert.assertTrue(Arrays.equals(new long[]{1L}, (long[])v.property("aLong").value()));
         Assert.assertTrue(Arrays.equals(new double[]{1d}, (double[])v.property("aDouble").value()));
         Assert.assertTrue(Arrays.equals(new String[]{"aaaaaaaaaaaaa"}, (String[])v.property("aString").value()));
 
@@ -101,7 +101,7 @@ public class TestLoadArrayProperties extends BaseTest {
         Assert.assertTrue(Arrays.equals(new boolean[]{true}, (boolean[])v.property("aBoolean").value()));
         Assert.assertTrue(Arrays.equals(new short[]{(short) 1}, (short[])v.property("aShort").value()));
         Assert.assertTrue(Arrays.equals(new int[]{1}, (int[])v.property("aInteger").value()));
-        Assert.assertTrue(Arrays.equals(new long[]{1l}, (long[])v.property("aLong").value()));
+        Assert.assertTrue(Arrays.equals(new long[]{1L}, (long[])v.property("aLong").value()));
         Assert.assertTrue(Arrays.equals(new double[]{1d}, (double[])v.property("aDouble").value()));
         Assert.assertTrue(Arrays.equals(new String[]{"aaaaaaaaaaaaa"}, (String[])v.property("aString").value()));
     }

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/TestSetProperty.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/TestSetProperty.java
@@ -49,14 +49,14 @@ public class TestSetProperty extends BaseTest {
         Vertex v = this.sqlgGraph.addVertex(T.label, "Person",
                 "age2", (short)1,
                 "age3", 1,
-                "age4", 1l,
+                "age4", 1L,
                 "age5", 1f,
                 "age6", 1d
         );
         this.sqlgGraph.tx().commit();
         Assert.assertEquals((short)1, v.property("age2").value());
         Assert.assertEquals(1, v.property("age3").value());
-        Assert.assertEquals(1l, v.property("age4").value());
+        Assert.assertEquals(1L, v.property("age4").value());
         Assert.assertEquals(1f, v.property("age5").value());
         Assert.assertEquals(1d, v.property("age6").value());
     }
@@ -66,13 +66,13 @@ public class TestSetProperty extends BaseTest {
         Vertex v = this.sqlgGraph.addVertex(T.label, "Person",
                 "age2", (short)1,
                 "age3", 1,
-                "age4", 1l,
+                "age4", 1L,
                 "age6", 1d
         );
         this.sqlgGraph.tx().commit();
         Assert.assertEquals((short)1, v.property("age2").value());
         Assert.assertEquals(1, v.property("age3").value());
-        Assert.assertEquals(1l, v.property("age4").value());
+        Assert.assertEquals(1L, v.property("age4").value());
         Assert.assertEquals(1d, v.property("age6").value());
     }
 
@@ -82,14 +82,14 @@ public class TestSetProperty extends BaseTest {
         Vertex v = this.sqlgGraph.addVertex(T.label, "Person",
                 "age2", new Short((short)1),
                 "age3", new Integer(1),
-                "age4", new Long(1l),
+                "age4", new Long(1L),
                 "age5", new Float(1f),
                 "age6", new Double(1d)
         );
         this.sqlgGraph.tx().commit();
         Assert.assertEquals(new Short((short)1), v.property("age2").value());
         Assert.assertEquals(new Integer(1), v.property("age3").value());
-        Assert.assertEquals(new Long(1l), v.property("age4").value());
+        Assert.assertEquals(new Long(1L), v.property("age4").value());
         Assert.assertEquals(new Float(1f), v.property("age5").value());
         Assert.assertEquals(new Double(1d), v.property("age6").value());
     }
@@ -99,13 +99,13 @@ public class TestSetProperty extends BaseTest {
         Vertex v = this.sqlgGraph.addVertex(T.label, "Person",
                 "age2", new Short((short)1),
                 "age3", new Integer(1),
-                "age4", new Long(1l),
+                "age4", new Long(1L),
                 "age6", new Double(1d)
         );
         this.sqlgGraph.tx().commit();
         Assert.assertEquals(new Short((short)1), v.property("age2").value());
         Assert.assertEquals(new Integer(1), v.property("age3").value());
-        Assert.assertEquals(new Long(1l), v.property("age4").value());
+        Assert.assertEquals(new Long(1L), v.property("age4").value());
         Assert.assertEquals(new Double(1d), v.property("age6").value());
     }
 

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/TinkerpopTest.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/TinkerpopTest.java
@@ -76,8 +76,8 @@ public class TinkerpopTest extends BaseTest {
         final Map<T, Long> expectedResultsCount = new HashMap<>();
         final Map<T, Long> resultsCount = new HashMap<>();
         assertEquals("Checking indexing is equivalent", expectedResultsCount.size(), resultsCount.size());
-        expectedResults.forEach(t -> MapHelper.incr(expectedResultsCount, t, 1l));
-        results.forEach(t -> MapHelper.incr(resultsCount, t, 1l));
+        expectedResults.forEach(t -> MapHelper.incr(expectedResultsCount, t, 1L));
+        results.forEach(t -> MapHelper.incr(resultsCount, t, 1L));
         expectedResultsCount.forEach((k, v) -> assertEquals("Checking result group counts", v, resultsCount.get(k)));
         Assert.assertFalse(traversal.hasNext());
     }

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/aggregate/TestAggregate.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/aggregate/TestAggregate.java
@@ -50,16 +50,16 @@ public class TestAggregate extends BaseTest {
             final String first = path.get(0).toString();
             final String second = path.get(1).toString();
             Assert.assertThat(first, CoreMatchers.not(second));
-            MapHelper.incr(firstStepCounts, first, 1l);
-            MapHelper.incr(secondStepCounts, second, 1l);
+            MapHelper.incr(firstStepCounts, first, 1L);
+            MapHelper.incr(secondStepCounts, second, 1L);
         }
         Assert.assertEquals(6, count);
         Assert.assertEquals(3, firstStepCounts.size());
         Assert.assertEquals(4, secondStepCounts.size());
-        Assert.assertTrue(firstStepCounts.values().contains(3l));
-        Assert.assertTrue(firstStepCounts.values().contains(2l));
-        Assert.assertTrue(firstStepCounts.values().contains(1l));
-        Assert.assertTrue(secondStepCounts.values().contains(3l));
-        Assert.assertTrue(secondStepCounts.values().contains(1l));
+        Assert.assertTrue(firstStepCounts.values().contains(3L));
+        Assert.assertTrue(firstStepCounts.values().contains(2L));
+        Assert.assertTrue(firstStepCounts.values().contains(1L));
+        Assert.assertTrue(secondStepCounts.values().contains(3L));
+        Assert.assertTrue(secondStepCounts.values().contains(1L));
     }
 }

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/batch/TestBatchedStreaming.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/batch/TestBatchedStreaming.java
@@ -162,7 +162,7 @@ public class TestBatchedStreaming extends BaseTest {
         this.sqlgGraph.tx().streamingBatchModeOn();
         uids.stream().forEach(u -> this.sqlgGraph.streamVertex(T.label, "R_HG.Person", "name", u));
         this.sqlgGraph.tx().commit();
-        Assert.assertEquals(5, this.sqlgGraph.traversal().V().hasLabel("R_HG.Person").count().next(), 0l);
+        Assert.assertEquals(5, this.sqlgGraph.traversal().V().hasLabel("R_HG.Person").count().next(), 0L);
     }
 
 
@@ -181,8 +181,8 @@ public class TestBatchedStreaming extends BaseTest {
         this.sqlgGraph.tx().streamingBatchModeOn();
         this.sqlgGraph.streamVertex("Person", new LinkedHashMap<>());
         this.sqlgGraph.tx().commit();
-        Assert.assertEquals(102, this.sqlgGraph.traversal().V().hasLabel("Person").count().next(), 0l);
-        Assert.assertEquals(1, this.sqlgGraph.traversal().V().hasLabel("Dog").count().next(), 0l);
+        Assert.assertEquals(102, this.sqlgGraph.traversal().V().hasLabel("Person").count().next(), 0L);
+        Assert.assertEquals(1, this.sqlgGraph.traversal().V().hasLabel("Dog").count().next(), 0L);
     }
 
     @Test

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/batch/TestStreamVertex.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/batch/TestStreamVertex.java
@@ -160,8 +160,8 @@ public class TestStreamVertex extends BaseTest {
         this.sqlgGraph.tx().streamingBatchModeOn();
         this.sqlgGraph.streamVertex("Persons", keyValue);
         this.sqlgGraph.tx().commit();
-        Assert.assertEquals(1, this.sqlgGraph.traversal().V().hasLabel("Person").count().next(), 0l);
-        Assert.assertEquals(1, this.sqlgGraph.traversal().V().hasLabel("Persons").count().next(), 0l);
+        Assert.assertEquals(1, this.sqlgGraph.traversal().V().hasLabel("Person").count().next(), 0L);
+        Assert.assertEquals(1, this.sqlgGraph.traversal().V().hasLabel("Persons").count().next(), 0L);
         Assert.assertEquals("a", this.sqlgGraph.traversal().V().hasLabel("Person").next().<String>value("name"));
         Assert.assertEquals("b", this.sqlgGraph.traversal().V().hasLabel("Person").next().<String>value("surname"));
         Assert.assertEquals("a", this.sqlgGraph.traversal().V().hasLabel("Persons").next().<String>value("name"));
@@ -210,7 +210,7 @@ public class TestStreamVertex extends BaseTest {
         keyValue.put("surname", "b");
         this.sqlgGraph.streamVertex("R_HG.Person", keyValue);
         this.sqlgGraph.tx().commit();
-        Assert.assertEquals(2, this.sqlgGraph.traversal().V().hasLabel("R_HG.Person").count().next(), 0l);
+        Assert.assertEquals(2, this.sqlgGraph.traversal().V().hasLabel("R_HG.Person").count().next(), 0L);
     }
 
     @Test
@@ -235,7 +235,7 @@ public class TestStreamVertex extends BaseTest {
         System.out.println(stopWatch.toString());
         stopWatch.reset();
         stopWatch.start();
-        Assert.assertEquals(1000000l, this.sqlgGraph.traversal().V().has(T.label, "Person").count().next().longValue());
+        Assert.assertEquals(1000000L, this.sqlgGraph.traversal().V().has(T.label, "Person").count().next().longValue());
         stopWatch.stop();
         System.out.println(stopWatch.toString());
     }
@@ -267,7 +267,7 @@ public class TestStreamVertex extends BaseTest {
         this.sqlgGraph.tx().streamingBatchModeOn();
         uids.stream().forEach(u->this.sqlgGraph.streamVertex(T.label, "Person", "name", u));
         this.sqlgGraph.tx().commit();
-        Assert.assertEquals(5, this.sqlgGraph.traversal().V().hasLabel("Person").count().next(), 0l);
+        Assert.assertEquals(5, this.sqlgGraph.traversal().V().hasLabel("Person").count().next(), 0L);
     }
 
     @Test

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/gremlincompile/TestGremlinCompileWithHas.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/gremlincompile/TestGremlinCompileWithHas.java
@@ -83,18 +83,18 @@ public class TestGremlinCompileWithHas extends BaseTest {
         this.sqlgGraph.tx().commit();
 
         long start = this.sqlgGraph.getSqlDialect().getPrimaryKeyStartValue();
-        RecordId recordIda1 = RecordId.from(SchemaTable.of(sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 0l);
+        RecordId recordIda1 = RecordId.from(SchemaTable.of(sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 0L);
         RecordId recordIda2 = RecordId.from(SchemaTable.of(sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 1l);
-        RecordId recordIda3 = RecordId.from(SchemaTable.of(sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 2l);
-        RecordId recordIda4 = RecordId.from(SchemaTable.of(sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 3l);
-        RecordId recordIdb1 = RecordId.from(SchemaTable.of(sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 0l);
-        RecordId recordIdb2 = RecordId.from(SchemaTable.of(sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 1l);
-        RecordId recordIdb3 = RecordId.from(SchemaTable.of(sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 2l);
-        RecordId recordIdb4 = RecordId.from(SchemaTable.of(sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 3l);
-        RecordId recordIdc1 = RecordId.from(SchemaTable.of(sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 0l);
-        RecordId recordIdc2 = RecordId.from(SchemaTable.of(sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 1l);
-        RecordId recordIdc3 = RecordId.from(SchemaTable.of(sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 2l);
-        RecordId recordIdc4 = RecordId.from(SchemaTable.of(sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 3l);
+        RecordId recordIda3 = RecordId.from(SchemaTable.of(sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 2L);
+        RecordId recordIda4 = RecordId.from(SchemaTable.of(sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 3L);
+        RecordId recordIdb1 = RecordId.from(SchemaTable.of(sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 0L);
+        RecordId recordIdb2 = RecordId.from(SchemaTable.of(sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 1L);
+        RecordId recordIdb3 = RecordId.from(SchemaTable.of(sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 2L);
+        RecordId recordIdb4 = RecordId.from(SchemaTable.of(sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 3L);
+        RecordId recordIdc1 = RecordId.from(SchemaTable.of(sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 0L);
+        RecordId recordIdc2 = RecordId.from(SchemaTable.of(sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 1L);
+        RecordId recordIdc3 = RecordId.from(SchemaTable.of(sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 2L);
+        RecordId recordIdc4 = RecordId.from(SchemaTable.of(sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 3L);
 
         List<Vertex> vertices = this.sqlgGraph.traversal().V(recordIda1).hasLabel("A").toList();
         Assert.assertEquals(1, vertices.size());
@@ -163,18 +163,18 @@ public class TestGremlinCompileWithHas extends BaseTest {
         this.sqlgGraph.tx().commit();
 
         long start = this.sqlgGraph.getSqlDialect().getPrimaryKeyStartValue();
-        RecordId recordIda1 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 0l);
-        RecordId recordIda2 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 1l);
-        RecordId recordIda3 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 2l);
-        RecordId recordIda4 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 3l);
-        RecordId recordIdb1 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 0l);
-        RecordId recordIdb2 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 1l);
-        RecordId recordIdb3 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 2l);
-        RecordId recordIdb4 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 3l);
-        RecordId recordIdc1 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 0l);
-        RecordId recordIdc2 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 1l);
-        RecordId recordIdc3 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 2l);
-        RecordId recordIdc4 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 3l);
+        RecordId recordIda1 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 0L);
+        RecordId recordIda2 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 1L);
+        RecordId recordIda3 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 2L);
+        RecordId recordIda4 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 3L);
+        RecordId recordIdb1 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 0L);
+        RecordId recordIdb2 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 1L);
+        RecordId recordIdb3 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 2L);
+        RecordId recordIdb4 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 3L);
+        RecordId recordIdc1 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 0L);
+        RecordId recordIdc2 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 1L);
+        RecordId recordIdc3 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 2L);
+        RecordId recordIdc4 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 3L);
 
         List<Vertex> vertices = this.sqlgGraph.traversal().V(recordIda1, recordIda2, recordIda3, recordIda4).in().hasId(recordIdb1, recordIdb2, recordIdb3).toList();
         Assert.assertEquals(3, vertices.size());
@@ -222,18 +222,18 @@ public class TestGremlinCompileWithHas extends BaseTest {
         this.sqlgGraph.tx().commit();
 
         long start = this.sqlgGraph.getSqlDialect().getPrimaryKeyStartValue();
-        RecordId recordIda1 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 0l);
-        RecordId recordIda2 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 1l);
-        RecordId recordIda3 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 2l);
-        RecordId recordIda4 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 3l);
-        RecordId recordIdb1 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 0l);
-        RecordId recordIdb2 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 1l);
-        RecordId recordIdb3 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 2l);
-        RecordId recordIdb4 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 3l);
-        RecordId recordIdc1 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 0l);
-        RecordId recordIdc2 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 1l);
-        RecordId recordIdc3 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 2l);
-        RecordId recordIdc4 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 3l);
+        RecordId recordIda1 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 0L);
+        RecordId recordIda2 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 1L);
+        RecordId recordIda3 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 2L);
+        RecordId recordIda4 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 3L);
+        RecordId recordIdb1 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 0L);
+        RecordId recordIdb2 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 1L);
+        RecordId recordIdb3 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 2L);
+        RecordId recordIdb4 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 3L);
+        RecordId recordIdc1 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 0L);
+        RecordId recordIdc2 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 1L);
+        RecordId recordIdc3 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 2L);
+        RecordId recordIdc4 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 3L);
 
         List<Vertex> vertices = this.sqlgGraph.traversal().V(recordIda1, recordIda2, recordIda3, recordIda4).out().hasId(recordIdb1, recordIdb2, recordIdb3).toList();
         Assert.assertEquals(3, vertices.size());
@@ -273,18 +273,18 @@ public class TestGremlinCompileWithHas extends BaseTest {
         this.sqlgGraph.tx().commit();
 
         long start = this.sqlgGraph.getSqlDialect().getPrimaryKeyStartValue();
-        RecordId recordIda1 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 0l);
-        RecordId recordIda2 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 1l);
-        RecordId recordIda3 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 2l);
-        RecordId recordIda4 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 3l);
-        RecordId recordIdb1 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 0l);
-        RecordId recordIdb2 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 1l);
-        RecordId recordIdb3 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 2l);
-        RecordId recordIdb4 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 3l);
-        RecordId recordIdc1 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 0l);
-        RecordId recordIdc2 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 1l);
-        RecordId recordIdc3 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 2l);
-        RecordId recordIdc4 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 3l);
+        RecordId recordIda1 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 0L);
+        RecordId recordIda2 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 1L);
+        RecordId recordIda3 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 2L);
+        RecordId recordIda4 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "A"), start + 3L);
+        RecordId recordIdb1 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 0L);
+        RecordId recordIdb2 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 1L);
+        RecordId recordIdb3 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 2L);
+        RecordId recordIdb4 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "B"), start + 3L);
+        RecordId recordIdc1 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 0L);
+        RecordId recordIdc2 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 1L);
+        RecordId recordIdc3 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 2L);
+        RecordId recordIdc4 = RecordId.from(SchemaTable.of(this.sqlgGraph.getSqlDialect().getPublicSchema(), "C"), start + 3L);
 
         List<Vertex> vertices = this.sqlgGraph.traversal().V(recordIda1).hasLabel("A").toList();
         Assert.assertEquals(1, vertices.size());
@@ -446,8 +446,8 @@ public class TestGremlinCompileWithHas extends BaseTest {
         final Map<T, Long> expectedResultsCount = new HashMap<>();
         final Map<T, Long> resultsCount = new HashMap<>();
         Assert.assertEquals("Checking indexing is equivalent", expectedResultsCount.size(), resultsCount.size());
-        expectedResults.forEach(t -> MapHelper.incr(expectedResultsCount, t, 1l));
-        results.forEach(t -> MapHelper.incr(resultsCount, t, 1l));
+        expectedResults.forEach(t -> MapHelper.incr(expectedResultsCount, t, 1L));
+        results.forEach(t -> MapHelper.incr(resultsCount, t, 1L));
         expectedResultsCount.forEach((k, v) -> Assert.assertEquals("Checking result group counts", v, resultsCount.get(k)));
         Assert.assertFalse(traversal.hasNext());
     }
@@ -553,7 +553,7 @@ public class TestGremlinCompileWithHas extends BaseTest {
                         __.in("created")
                                 .count()
                                 .is(
-                                        P.gte(2l)
+                                        P.gte(2L)
                                 )
                 )
                 .values("name");

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/gremlincompile/TestRepeatStepGraphOut.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/gremlincompile/TestRepeatStepGraphOut.java
@@ -99,13 +99,13 @@ public class TestRepeatStepGraphOut extends BaseTest {
         assertTrue(t.get(0).containsKey("c1"));
         assertTrue(t.get(0).containsKey("c1"));
 
-        assertEquals(1l, t.get(0).get("a1"));
-        assertEquals(2l, t.get(0).get("b1"));
-        assertEquals(2l, t.get(0).get("b2"));
-        assertEquals(2l, t.get(0).get("b3"));
-        assertEquals(2l, t.get(0).get("c1"));
-        assertEquals(2l, t.get(0).get("c2"));
-        assertEquals(2l, t.get(0).get("c3"));
+        assertEquals(1L, t.get(0).get("a1"));
+        assertEquals(2L, t.get(0).get("b1"));
+        assertEquals(2L, t.get(0).get("b2"));
+        assertEquals(2L, t.get(0).get("b3"));
+        assertEquals(2L, t.get(0).get("c1"));
+        assertEquals(2L, t.get(0).get("c2"));
+        assertEquals(2L, t.get(0).get("c3"));
     }
 
     @Test
@@ -136,13 +136,13 @@ public class TestRepeatStepGraphOut extends BaseTest {
         assertTrue(t.get(0).containsKey("c1"));
         assertTrue(t.get(0).containsKey("c1"));
 
-        assertEquals(1l, t.get(0).get("a1"));
-        assertEquals(2l, t.get(0).get("b1"));
-        assertEquals(2l, t.get(0).get("b2"));
-        assertEquals(2l, t.get(0).get("b3"));
-        assertEquals(2l, t.get(0).get("c1"));
-        assertEquals(2l, t.get(0).get("c2"));
-        assertEquals(2l, t.get(0).get("c3"));
+        assertEquals(1L, t.get(0).get("a1"));
+        assertEquals(2L, t.get(0).get("b1"));
+        assertEquals(2L, t.get(0).get("b2"));
+        assertEquals(2L, t.get(0).get("b3"));
+        assertEquals(2L, t.get(0).get("c1"));
+        assertEquals(2L, t.get(0).get("c2"));
+        assertEquals(2L, t.get(0).get("c3"));
     }
 
     @Test
@@ -788,7 +788,7 @@ public class TestRepeatStepGraphOut extends BaseTest {
             int counter = 0;
             while (traversal.hasNext()) {
                 counter++;
-                MapHelper.incr(pathLengths, traversal.next().size(), 1l);
+                MapHelper.incr(pathLengths, traversal.next().size(), 1L);
             }
             assertEquals(2, pathLengths.size());
             assertEquals(8, counter);

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/vertexstep/localvertexstep/TestLocalVertexStepRepeatStep.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/vertexstep/localvertexstep/TestLocalVertexStepRepeatStep.java
@@ -701,7 +701,7 @@ public class TestLocalVertexStepRepeatStep extends BaseTest {
             int counter = 0;
             while (traversal.hasNext()) {
                 counter++;
-                MapHelper.incr(pathLengths, traversal.next().size(), 1l);
+                MapHelper.incr(pathLengths, traversal.next().size(), 1L);
             }
             assertEquals(2, pathLengths.size());
             assertEquals(8, counter);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:LowerCaseLongSuffixCheck - Long suffix L should be upper case.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:LowerCaseLongSuffixCheck
Please let me know if you have any questions.
George Kankava