### PR TITLE
use column indices instead of names where possible

### DIFF
--- a/sqlg-core/src/main/java/org/umlg/sqlg/sql/parse/SchemaTableTree.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/sql/parse/SchemaTableTree.java
@@ -1994,27 +1994,33 @@ public class SchemaTableTree {
     }
 
     public void loadProperty(ResultSet resultSet, SqlgElement sqlgElement) throws SQLException {
-        for (Map.Entry<String, Pair<String, PropertyType>> entry : getColumnNamePropertyName().entrySet()) {
-            String columnName = entry.getKey();
-            String propertyName = entry.getValue().getKey();
-            PropertyType propertyType = entry.getValue().getValue();
-            //make sure that if we request an array-backed type, we do it using
-            //the getArray() call. Don't bother for byte arrays, because they are
-            //handled differently by all supported DBs, so getObject() on them
-            //works.
-            Object o = (propertyType != null && propertyType.isArray()
-                    && propertyType != PropertyType.byte_ARRAY
-                    && propertyType != PropertyType.BYTE_ARRAY)
-                    ? resultSet.getArray(columnName)
-                    : resultSet.getObject(columnName);
-            if (!Objects.isNull(o)) {
-                if (propertyName.endsWith(SchemaManager.IN_VERTEX_COLUMN_END)) {
-                    ((SqlgEdge) sqlgElement).loadInVertex(resultSet, propertyName, columnName);
-                } else if (propertyName.endsWith(SchemaManager.OUT_VERTEX_COLUMN_END)) {
-                    ((SqlgEdge) sqlgElement).loadOutVertex(resultSet, propertyName, columnName);
-                } else {
-                    sqlgElement.loadProperty(resultSet, propertyName, o, getColumnNameAliasMap(), this.stepDepth, propertyType);
-                }
+    	for (int ix=1;ix<=resultSet.getMetaData().getColumnCount();ix++){
+    		
+        //for (Map.Entry<String, Pair<String, PropertyType>> entry : getColumnNamePropertyName().entrySet()) {
+            String columnName = resultSet.getMetaData().getColumnLabel(ix);//entry.getKey();
+            Pair<String, PropertyType> p=getColumnNamePropertyName().get(columnName);
+            if (p!=null){
+	            String propertyName = p.getKey();
+	            PropertyType propertyType = p.getValue();
+	            
+	            //make sure that if we request an array-backed type, we do it using
+	            //the getArray() call. Don't bother for byte arrays, because they are
+	            //handled differently by all supported DBs, so getObject() on them
+	            //works.
+	            Object o = (propertyType != null && propertyType.isArray()
+	                    && propertyType != PropertyType.byte_ARRAY
+	                    && propertyType != PropertyType.BYTE_ARRAY)
+	                    ? resultSet.getArray(ix)
+	                    : resultSet.getObject(ix);
+	            if (!Objects.isNull(o)) {
+	                if (propertyName.endsWith(SchemaManager.IN_VERTEX_COLUMN_END)) {
+	                    ((SqlgEdge) sqlgElement).loadInVertex(resultSet, propertyName, ix);
+	                } else if (propertyName.endsWith(SchemaManager.OUT_VERTEX_COLUMN_END)) {
+	                    ((SqlgEdge) sqlgElement).loadOutVertex(resultSet, propertyName, ix);
+	                } else {
+	                    sqlgElement.loadProperty(resultSet, propertyName, o, getColumnNameAliasMap(), this.stepDepth, propertyType);
+	                }
+	            }
             }
         }
     }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgGraph.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgGraph.java
@@ -1074,7 +1074,7 @@ public class SqlgGraph implements Graph {
                     int type = rsmd.getColumnType(i);
                     //make sure to obtain array using getArray()
                     //At least in H2, this makes a difference...
-                    Object o = type == Types.ARRAY ? rs.getArray(columnName) : rs.getObject(columnName);
+                    Object o = type == Types.ARRAY ? rs.getArray(i) : rs.getObject(i);
                     this.sqlDialect.putJsonObject(obj, columnName, type, o);
                     if (first) {
                         this.sqlDialect.putJsonMetaObject(this.mapper, metaNode, columnName, type, o);

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgVertex.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgVertex.java
@@ -297,29 +297,35 @@ public class SqlgVertex extends SqlgElement implements Vertex {
 
                     ResultSet resultSet = preparedStatement.executeQuery();
                     while (resultSet.next()) {
-                        Set<String> inVertexColumnNames = new HashSet<>();
-                        Set<String> outVertexColumnNames = new HashSet<>();
-                        String inVertexColumnName = "";
-                        String outVertexColumnName = "";
+                        Set<Integer> inVertexColumnIndexs = new HashSet<>();
+                        Set<Integer> outVertexColumnIndexs = new HashSet<>();
+                        int inVertexColumnIndex = 0;
+                        int outVertexColumnIndex = 0;
                         ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
+                        int idIdx=0;
                         for (int i = 1; i <= resultSetMetaData.getColumnCount(); i++) {
                             String columnName = resultSetMetaData.getColumnLabel(i);
                             if (columnName.endsWith(SchemaManager.IN_VERTEX_COLUMN_END)) {
-                                inVertexColumnNames.add(columnName);
+                                inVertexColumnIndexs.add(i);
                             } else if (columnName.endsWith(SchemaManager.OUT_VERTEX_COLUMN_END)) {
-                                outVertexColumnNames.add(columnName);
+                                outVertexColumnIndexs.add(i);
+                            } else if (columnName.equals(SchemaManager.ID)){
+                            	idIdx=i;
                             }
                         }
-                        if (inVertexColumnNames.isEmpty() || outVertexColumnNames.isEmpty()) {
+                        if (inVertexColumnIndexs.isEmpty() || outVertexColumnIndexs.isEmpty()) {
                             throw new IllegalStateException("BUG: in or out vertex id not set!!!!");
                         }
+                        if (idIdx==0) {
+                            throw new IllegalStateException("BUG: no ID column!!!!");
+                        }
 
-                        Long edgeId = resultSet.getLong("ID");
+                        Long edgeId = resultSet.getLong(idIdx);
                         Long inId = null;
                         Long outId = null;
 
                         //Only one in out pair should ever be set per row
-                        for (String inColumnName : inVertexColumnNames) {
+                        for (Integer inColumnName : inVertexColumnIndexs) {
                             if (inId != null) {
                                 @SuppressWarnings("unused")
                                 Long tempInId = resultSet.getLong(inColumnName);
@@ -330,11 +336,11 @@ public class SqlgVertex extends SqlgElement implements Vertex {
                                 Long tempInId = resultSet.getLong(inColumnName);
                                 if (!resultSet.wasNull()) {
                                     inId = tempInId;
-                                    inVertexColumnName = inColumnName;
+                                    inVertexColumnIndex = inColumnName;
                                 }
                             }
                         }
-                        for (String outColumnName : outVertexColumnNames) {
+                        for (Integer outColumnName : outVertexColumnIndexs) {
                             if (outId != null) {
                                 @SuppressWarnings("unused")
                                 Long tempOutId = resultSet.getLong(outColumnName);
@@ -345,22 +351,22 @@ public class SqlgVertex extends SqlgElement implements Vertex {
                                 Long tempOutId = resultSet.getLong(outColumnName);
                                 if (!resultSet.wasNull()) {
                                     outId = tempOutId;
-                                    outVertexColumnName = outColumnName;
+                                    outVertexColumnIndex = outColumnName;
                                 }
                             }
                         }
-                        if (inVertexColumnName.isEmpty() || outVertexColumnName.isEmpty()) {
-                            throw new IllegalStateException("inVertexColumnName or outVertexColumnName is empty!");
+                        if (inVertexColumnIndex==0 || outVertexColumnIndex==0) {
+                            throw new IllegalStateException("inVertexColumnIndex or outVertexColumnIndex is unknown!");
                         }
-                        SchemaTable inSchemaTable = SchemaTable.from(this.sqlgGraph, inVertexColumnName, this.sqlgGraph.getSqlDialect().getPublicSchema());
-                        SchemaTable outSchemaTable = SchemaTable.from(this.sqlgGraph, outVertexColumnName, this.sqlgGraph.getSqlDialect().getPublicSchema());
+                        SchemaTable inSchemaTable = SchemaTable.from(this.sqlgGraph, resultSetMetaData.getColumnLabel(inVertexColumnIndex), this.sqlgGraph.getSqlDialect().getPublicSchema());
+                        SchemaTable outSchemaTable = SchemaTable.from(this.sqlgGraph, resultSetMetaData.getColumnLabel(outVertexColumnIndex), this.sqlgGraph.getSqlDialect().getPublicSchema());
 
                         List<Object> keyValues = new ArrayList<>();
                         for (int i = 1; i <= resultSetMetaData.getColumnCount(); i++) {
                             String columnName = resultSetMetaData.getColumnLabel(i);
-                            if (!((columnName.equals("ID") || columnName.equals(inVertexColumnNames) || columnName.equals(outVertexColumnNames)))) {
+                            if (!((columnName.equals("ID") || columnName.equals(inVertexColumnIndexs) || columnName.equals(outVertexColumnIndexs)))) {
                                 keyValues.add(columnName);
-                                keyValues.add(resultSet.getObject(columnName));
+                                keyValues.add(resultSet.getObject(i));
                             }
                         }
                         SqlgEdge sqlGEdge = null;
@@ -723,20 +729,20 @@ public class SqlgVertex extends SqlgElement implements Vertex {
                         }
                         ResultSet resultSet = preparedStatement.executeQuery();
                         while (resultSet.next()) {
-                            Set<String> inVertexColumnNames = new HashSet<>();
-                            Set<String> outVertexColumnNames = new HashSet<>();
-                            String inVertexColumnName = "";
-                            String outVertexColumnName = "";
+                            Set<Integer> inVertexColumnIndexes = new HashSet<>();
+                            Set<Integer> outVertexColumnIndexes = new HashSet<>();
+                            int inVertexColumnIndex = 0;
+                            int outVertexColumnIndex = 0;
                             ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
                             for (int i = 1; i <= resultSetMetaData.getColumnCount(); i++) {
                                 String columnName = resultSetMetaData.getColumnLabel(i);
                                 if (columnName.endsWith(SchemaManager.IN_VERTEX_COLUMN_END)) {
-                                    inVertexColumnNames.add(columnName);
+                                    inVertexColumnIndexes.add(i);
                                 } else if (columnName.endsWith(SchemaManager.OUT_VERTEX_COLUMN_END)) {
-                                    outVertexColumnNames.add(columnName);
+                                    outVertexColumnIndexes.add(i);
                                 }
                             }
-                            if (inVertexColumnNames.isEmpty() && outVertexColumnNames.isEmpty()) {
+                            if (inVertexColumnIndexes.isEmpty() && outVertexColumnIndexes.isEmpty()) {
                                 throw new IllegalStateException("BUG: in or out vertex id not set!!!!");
                             }
 
@@ -744,7 +750,7 @@ public class SqlgVertex extends SqlgElement implements Vertex {
                             Long outId = null;
 
                             //Only one in out pair should ever be set per row
-                            for (String inColumnName : inVertexColumnNames) {
+                            for (Integer inColumnName : inVertexColumnIndexes) {
                                 if (inId != null) {
                                     resultSet.getLong(inColumnName);
                                     if (!resultSet.wasNull()) {
@@ -754,11 +760,11 @@ public class SqlgVertex extends SqlgElement implements Vertex {
                                     Long tempInId = resultSet.getLong(inColumnName);
                                     if (!resultSet.wasNull()) {
                                         inId = tempInId;
-                                        inVertexColumnName = inColumnName;
+                                        inVertexColumnIndex = inColumnName;
                                     }
                                 }
                             }
-                            for (String outColumnName : outVertexColumnNames) {
+                            for (Integer outColumnName : outVertexColumnIndexes) {
                                 if (outId != null) {
                                     resultSet.getLong(outColumnName);
                                     if (!resultSet.wasNull()) {
@@ -768,22 +774,22 @@ public class SqlgVertex extends SqlgElement implements Vertex {
                                     Long tempOutId = resultSet.getLong(outColumnName);
                                     if (!resultSet.wasNull()) {
                                         outId = tempOutId;
-                                        outVertexColumnName = outColumnName;
+                                        outVertexColumnIndex = outColumnName;
                                     }
                                 }
                             }
-                            if (inVertexColumnName.isEmpty() && outVertexColumnName.isEmpty()) {
-                                throw new IllegalStateException("inVertexColumnName or outVertexColumnName is empty!");
+                            if (inVertexColumnIndex==0 && outVertexColumnIndex==0) {
+                                throw new IllegalStateException("inVertexColumnIndex or outVertexColumnIndex is unknown!");
                             }
 
                             List<Object> keyValues = new ArrayList<>();
                             for (int i = 1; i <= resultSetMetaData.getColumnCount(); i++) {
                                 String columnName = resultSetMetaData.getColumnLabel(i);
                                 if (!(columnName.equals("ID") ||
-                                        inVertexColumnNames.contains(columnName) || outVertexColumnNames.contains(columnName))) {
+                                        inVertexColumnIndexes.contains(columnName) || outVertexColumnIndexes.contains(columnName))) {
                                     //this values end up in SqlElement.properties.
                                     //Its a ConcurrentHashMap which does not allow null key or value
-                                    Object object = resultSet.getObject(columnName);
+                                    Object object = resultSet.getObject(i);
                                     if (object != null) {
                                         keyValues.add(columnName);
                                         keyValues.add(object);
@@ -927,7 +933,7 @@ public class SqlgVertex extends SqlgElement implements Vertex {
         ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
         for (int i = 1; i <= resultSetMetaData.getColumnCount(); i++) {
             String columnName = resultSetMetaData.getColumnLabel(i);
-            Object o = resultSet.getObject(columnName);
+            Object o = resultSet.getObject(i);
             if (!columnName.equals("ID")
                     && !columnName.equals(SchemaManager.VERTEX_SCHEMA)
                     && !columnName.equals(VERTEX_TABLE)


### PR DESCRIPTION
fixes #60 , except in one case where we want to read the ID column. Let me know of other places I've missed.