### PR TITLE
schema existence check

### DIFF
--- a/sqlg-core/src/main/java/org/umlg/sqlg/sql/dialect/SqlDialect.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/sql/dialect/SqlDialect.java
@@ -256,6 +256,14 @@ public interface SqlDialect {
         return "CREATE TEMPORARY TABLE ";
     }
 
+    /**
+     * 
+     * @return the statement head to create a schema
+     */
+    default String createSchemaStatement() {
+        return "CREATE SCHEMA ";
+    }
+    
     default void prepareDB(Connection conn) {
     }
 

--- a/sqlg-h2-parent/sqlg-h2-dialect/src/main/java/org/umlg/sqlg/H2Dialect.java
+++ b/sqlg-h2-parent/sqlg-h2-dialect/src/main/java/org/umlg/sqlg/H2Dialect.java
@@ -44,6 +44,12 @@ public class H2Dialect extends BaseSqlDialect {
     public Set<String> getDefaultSchemas() {
         return ImmutableSet.of("PUBLIC", "INFORMATION_SCHEMA");
     }
+    
+    @Override
+    public String createSchemaStatement() {
+    	// if ever schema is created outside of sqlg while the graph is already instantiated
+    	return "CREATE SCHEMA IF NOT EXISTS ";
+    }
 
     @Override
     public PropertyType sqlTypeToPropertyType(SqlgGraph sqlgGraph, String schema, String table, String column,

--- a/sqlg-postgres-parent/sqlg-postgres-dialect/src/main/java/org/umlg/sqlg/sql/dialect/PostgresDialect.java
+++ b/sqlg-postgres-parent/sqlg-postgres-dialect/src/main/java/org/umlg/sqlg/sql/dialect/PostgresDialect.java
@@ -65,6 +65,12 @@ public class PostgresDialect extends BaseSqlDialect {
     public String dialectName() {
         return "Postgresql";
     }
+    
+    @Override
+    public String createSchemaStatement() {
+    	// if ever schema is created outside of sqlg while the graph is already instantiated
+    	return "CREATE SCHEMA IF NOT EXISTS ";
+    }
 
     @Override
     public boolean supportsBatchMode() {

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/schema/TestSchema.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/schema/TestSchema.java
@@ -6,10 +6,13 @@ import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Assert;
 import org.junit.Test;
+import org.umlg.sqlg.structure.SchemaManager;
 import org.umlg.sqlg.structure.SchemaTable;
 import org.umlg.sqlg.test.BaseTest;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 import java.util.Map;
@@ -137,6 +140,26 @@ public class TestSchema extends BaseTest {
         assertEquals(1, this.sqlgGraph.traversal().E().hasLabel("A.eee").count().next().intValue());
         assertEquals(0, this.sqlgGraph.traversal().E().hasLabel("B.eee").count().next().intValue());
         assertEquals(0, this.sqlgGraph.traversal().E().hasLabel("public.eee").count().next().intValue());
+    }
+    
+    @Test
+    public void testEnsureSchema(){
+    	SchemaManager mgr=this.sqlgGraph.getSchemaManager();
+    	this.sqlgGraph.addVertex(T.label, "A.A");
+    	this.sqlgGraph.tx().commit();
+
+    	assertTrue(mgr.schemaExist(this.sqlgGraph.getSqlDialect().getPublicSchema()));
+    	assertTrue(mgr.schemaExist("A"));
+    	assertTrue(mgr.ensureSchemaExists("A"));
+    	
+    	assertFalse(mgr.schemaExist("B"));
+    	// false means didn't exist
+    	assertFalse(mgr.ensureSchemaExists("B"));
+    	// not committed yet
+    	assertFalse(mgr.schemaExist("B"));
+    	this.sqlgGraph.tx().commit();
+    	assertTrue(mgr.schemaExist("B"));
+    	
     }
 
 }


### PR DESCRIPTION
This allows us to check if a schema exists and create it if it doesn't, in a safe way (using the proper transaction, locking and internal structures). I have this need because in an app I want to store info in other tables (non sqlg managed) in the schema, possibly before sqlg has created it. So now I can call ensureSchemaExists and be sure everything should work fine!