### PR TITLE
Multiple compiled graph steps

### DIFF
--- a/sqlg-core/src/main/java/org/umlg/sqlg/strategy/BaseSqlgStrategy.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/strategy/BaseSqlgStrategy.java
@@ -120,8 +120,11 @@ public abstract class BaseSqlgStrategy extends AbstractTraversalStrategy<Travers
                     pathCount++;
 
                     ReplacedStep replacedStep = ReplacedStep.from(this.sqlgGraph.getSchemaManager(), (AbstractStep) step, pathCount);
-                    if (sqlgStep == null) {
+                    if (sqlgStep == null || step instanceof GraphStep) {
                         sqlgStep = constructSqlgStep(traversal, step);
+                        if (previous!=null){
+                        	sqlgStep.setPreviousStep(previous);
+                        }
                         alreadyReplacedGraphStep = alreadyReplacedGraphStep || step instanceof GraphStep;
                         //TODO this suck but brain is stuck.
                         if (this instanceof SqlgGraphStepStrategy) {
@@ -181,7 +184,7 @@ public abstract class BaseSqlgStrategy extends AbstractTraversalStrategy<Travers
                             replacedStep.addLabel(pathCount + BaseSqlgStrategy.PATH_LABEL_SUFFIX + BaseSqlgStrategy.SQLG_PATH_FAKE_LABEL);
                         }
                     }
-                    if (previous != null) {
+                    if (previous != null && !(step instanceof GraphStep)) {
                         sqlgStep.addReplacedStep(replacedStep);
                         int index = TraversalHelper.stepIndex(step, traversal);
                         if (index != -1) {

--- a/sqlg-core/src/main/java/org/umlg/sqlg/strategy/SqlgGraphStepStrategy.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/strategy/SqlgGraphStepStrategy.java
@@ -75,7 +75,7 @@ public class SqlgGraphStepStrategy extends BaseSqlgStrategy {
 
     @Override
     protected boolean isReplaceableStep(Class<? extends Step> stepClass, boolean alreadyReplacedGraphStep) {
-        return CONSECUTIVE_STEPS_TO_REPLACE.contains(stepClass) && !(stepClass.isAssignableFrom(GraphStep.class) && alreadyReplacedGraphStep);
+        return CONSECUTIVE_STEPS_TO_REPLACE.contains(stepClass);// && !(stepClass.isAssignableFrom(GraphStep.class) && alreadyReplacedGraphStep);
     }
 
     @Override

--- a/sqlg-test/src/main/java/org/umlg/sqlg/AllTest.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/AllTest.java
@@ -7,6 +7,7 @@ import org.umlg.sqlg.test.batch.*;
 import org.umlg.sqlg.test.edgehas.TestEdgeHas;
 import org.umlg.sqlg.test.edges.*;
 import org.umlg.sqlg.test.github.TestGithub;
+import org.umlg.sqlg.test.graph.MidTraversalGraphTest;
 import org.umlg.sqlg.test.graph.TestEmptyGraph;
 import org.umlg.sqlg.test.graph.TestGraphStepWithIds;
 import org.umlg.sqlg.test.gremlincompile.*;
@@ -143,7 +144,8 @@ import org.umlg.sqlg.test.vertexstep.localvertexstep.*;
         TestEscapedValues.class,
         TestRepeatStepOnEdges.class,
         TestLoadingAdjacent.class,
-        TestLabelsSchema.class
+        TestLabelsSchema.class,
+        MidTraversalGraphTest.class
         //TODO fails, issue #65
 //        TestEdgeFromDifferentSchema.class
 })

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/graph/MidTraversalGraphTest.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/graph/MidTraversalGraphTest.java
@@ -1,0 +1,59 @@
+package org.umlg.sqlg.test.graph;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.DefaultGraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.junit.Test;
+import org.umlg.sqlg.test.BaseTest;
+
+/**
+ * test graph steps in the middle of traversal
+ * @author jpmoresmau
+ *
+ */
+public class MidTraversalGraphTest extends BaseTest {
+
+	public MidTraversalGraphTest() {
+		
+	}
+	
+	@Test
+	public void testMidTraversalV(){
+        Vertex a1 = this.sqlgGraph.addVertex(T.label, "A", "name", "a1");
+        Vertex b1 = this.sqlgGraph.addVertex(T.label, "B", "name", "b1");
+        this.sqlgGraph.addVertex(T.label, "C", "name", "c1");
+        GraphTraversal<Vertex, Map<String,Object>> g= this.sqlgGraph.traversal().V().hasLabel("A").as("a").V().hasLabel("B").as("b").select("a", "b");
+        List<Map<String,Object>> l =g.toList();
+        
+        assertEquals(1, l.size());
+        Map<String,Object> m=l.get(0);
+        assertEquals(2,m.size());
+        assertEquals(a1,m.get("a"));
+        assertEquals(b1,m.get("b"));
+        
+        ensureCompiledGraphStep(g,2);
+	}
+
+	/**
+	 * ensure once we've built the traversal, it contains a RangeGlobalStep
+	 * @param g
+	 */
+	private void ensureCompiledGraphStep(GraphTraversal<?, ?>g, int expectedCount){
+		DefaultGraphTraversal<?, ?> dgt=(DefaultGraphTraversal<?, ?>)g;
+		int count=0;
+		for (Step<?, ?> s:dgt.getSteps()){
+			if (s.getClass().getSimpleName().equals("SqlgGraphStepCompiled")){
+				count++;
+			}
+		}
+		assertEquals(expectedCount,count);
+	}
+	
+}


### PR DESCRIPTION
Fixes #110, at least in some cases. We now allow SqlgGraphStepCompiled to appear in the middle of the traversal. This should help performance.