### PR TITLE
Can turn off lazy reading of the SQL results (fixes #125)

### DIFF
--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgVertex.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgVertex.java
@@ -228,17 +228,13 @@ public class SqlgVertex extends SqlgElement implements Vertex {
         if (this.sqlgGraph.features().supportsBatchMode() && this.sqlgGraph.tx().isInBatchMode() && this.sqlgGraph.tx().getBatchManager().vertexIsCached(this)) {
             this.sqlgGraph.tx().flush();
         }
-        //for some very bezaar reason not adding toList().iterator() return one extra element.
         switch (direction) {
             case OUT:
-                return this.sqlgGraph.traversal().V(this).outE(labels).toList().iterator();
-//                return this.sqlgGraph.traversal().V(this).outE(labels);
+                return this.sqlgGraph.traversal().V(this).outE(labels);
             case IN:
-                return this.sqlgGraph.traversal().V(this).inE(labels).toList().iterator();
-//                return this.sqlgGraph.traversal().V(this).inE(labels);
+                return this.sqlgGraph.traversal().V(this).inE(labels);
             case BOTH:
-                return this.sqlgGraph.traversal().V(this).bothE(labels).toList().iterator();
-//                return this.sqlgGraph.traversal().V(this).bothE(labels);
+                return this.sqlgGraph.traversal().V(this).bothE(labels);
         }
         return Collections.emptyIterator();
     }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/TransactionCache.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/TransactionCache.java
@@ -18,18 +18,26 @@ class TransactionCache {
     private boolean cacheVertices = false;
     private Map<RecordId, SqlgVertex> vertexCache = new WeakHashMap<>();
 
-    static TransactionCache of(boolean cacheVertices, Connection connection, BatchManager batchManager) {
-        return new TransactionCache(cacheVertices, connection, batchManager);
+    /**
+     * are query result processed lazily or not?
+     */
+    private boolean lazyQueries;
+
+
+	static TransactionCache of(boolean cacheVertices, Connection connection, BatchManager batchManager,boolean lazyQueries) {
+        return new TransactionCache(cacheVertices, connection, batchManager,lazyQueries);
     }
 
     private TransactionCache(
             boolean cacheVertices,
             Connection connection,
-            BatchManager batchManager) {
+            BatchManager batchManager,
+            boolean lazyQueries) {
 
         this.cacheVertices = cacheVertices;
         this.connection = connection;
         this.batchManager = batchManager;
+        this.lazyQueries = lazyQueries;
     }
 
     Connection getConnection() {
@@ -112,5 +120,21 @@ class TransactionCache {
             this.vertexCache.put(recordId, sqlgVertex);
         }
     }
+    
+    /**
+     * are we reading the SQL query results laszily?
+     * @return true if we are processing the results lazily, false otherwise
+     */
+    public boolean isLazyQueries() {
+		return lazyQueries;
+	}
+
+    /**
+     * set the laziness on query result reading
+     * @param lazy
+     */
+	public void setLazyQueries(boolean lazyQueries) {
+		this.lazyQueries = lazyQueries;
+	}
 
 }

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/gremlincompile/TestGremlinCompileE.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/gremlincompile/TestGremlinCompileE.java
@@ -89,6 +89,7 @@ public class TestGremlinCompileE extends BaseTest {
         v1.addEdge("pets", v2);
         v1.addEdge("walks", v2, "location", "arroyo");
         v2.addEdge("knows", v1, "since", 2010);
+        this.sqlgGraph.tx().setLazyQueries(false);
         assertEquals(4, vertexTraversal(v1).bothE().count().next().intValue());
         assertEquals(4, vertexTraversal(v2).bothE().count().next().intValue());
         v1.edges(Direction.BOTH).forEachRemaining(edge -> {

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/vertex/TestVertexEdges.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/vertex/TestVertexEdges.java
@@ -1,5 +1,8 @@
 package org.umlg.sqlg.test.vertex;
 
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.T;
@@ -8,24 +11,31 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.umlg.sqlg.test.BaseTest;
 
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-
 /**
  * Date: 2016/12/13
  * Time: 4:36 PM
  */
 public class TestVertexEdges extends BaseTest {
 
+	
     @Test
-    public void testVertexEdges() {
+    public void testVertexEdgesEager() {
+    	testVertexEdges(false);
+    }
+    
+    @Test
+    public void testVertexEdgesLazy() {
+    	testVertexEdges(true);
+    }
+    
+    private void testVertexEdges(boolean lazy){
         final Vertex a1 = this.sqlgGraph.addVertex(T.label, "A");
         final Vertex b1 = this.sqlgGraph.addVertex(T.label, "B");
         final Vertex c1 = this.sqlgGraph.addVertex(T.label, "C");
         a1.addEdge("ab", b1);
         a1.addEdge("ac", c1);
         this.sqlgGraph.tx().commit();
-
+        this.sqlgGraph.tx().setLazyQueries(lazy);
         AtomicInteger count = new AtomicInteger(0);
         a1.edges(Direction.BOTH).forEachRemaining(e->count.incrementAndGet());
         Assert.assertEquals(2, count.get());
@@ -34,9 +44,43 @@ public class TestVertexEdges extends BaseTest {
             a1.addEdge("ab", b1);
             count.getAndIncrement();
         });
-        Assert.assertEquals(2, count.get());
+        Assert.assertEquals(lazy?3:2, count.get());
+        
     }
+    
+    @Test
+    public void testVertexEdgesTraversalEager() {
+    	testVertexEdgesTraversal(false);
+    }
+    
+    @Test
+    public void testVertexEdgesTraversalLazy() {
+    	testVertexEdgesTraversal(true);
+    }
+    
+    private void testVertexEdgesTraversal(boolean lazy) {
+        final Vertex a1 = this.sqlgGraph.addVertex(T.label, "A");
+        final Vertex b1 = this.sqlgGraph.addVertex(T.label, "B");
+        final Vertex c1 = this.sqlgGraph.addVertex(T.label, "C");
+        a1.addEdge("ab", b1);
+        a1.addEdge("ac", c1);
+        this.sqlgGraph.tx().commit();
+        this.sqlgGraph.tx().setLazyQueries(lazy);
+        AtomicInteger count = new AtomicInteger(0);
+        a1.edges(Direction.BOTH).forEachRemaining(e->count.incrementAndGet());
+        Assert.assertEquals(2, count.get());
+        count.set(0);
+        vertexTraversal(a1).bothE().forEachRemaining(edge -> {
+            a1.addEdge("ab", b1);
+            count.getAndIncrement();
+        });
+        Assert.assertEquals(lazy?3:2, count.get());
+        
+        
+    }
+    
 
+    
     @Test
     public void testBothEOnEdgeToSelf() {
         final Vertex v1 = this.sqlgGraph.addVertex("name", "marko");
@@ -47,6 +91,7 @@ public class TestVertexEdges extends BaseTest {
         v2.addEdge("knows", v1, "since", 2010);
         Assert.assertEquals(4, vertexTraversal(v1).bothE().count().next().intValue());
         Assert.assertEquals(4, vertexTraversal(v2).bothE().count().next().intValue());
+        this.sqlgGraph.tx().setLazyQueries(false);
         v1.edges(Direction.BOTH).forEachRemaining(edge -> {
             v1.addEdge("livesWith", v2);
             v1.addEdge("walks", v2, "location", "river");


### PR DESCRIPTION
As discusses in #125, we can turn off the lazy reading of results, which allows us to have traversals that modify the items they were reading with proper semantics. This is not enabled by default because of course it can take a lot more memory (for example, the test doing the upgrade of the GratefulDead DB fails with an OutOfMemoryError). Eager mode can be enabled at runtime for the current transaction (`setLazyQueries(false)`) or for all transactions at configuration time (`query.lazy=false`). Let me know if that's not acceptable and we can of course review. PostgresAllTests pass on my machine.