### PR TITLE
support existing schema

### DIFF
--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/Schema.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/Schema.java
@@ -244,7 +244,7 @@ public class Schema implements TopologyInf {
      */
     private void createSchemaOnDb() {
         StringBuilder sql = new StringBuilder();
-        sql.append("CREATE SCHEMA ");
+        sql.append(topology.getSqlgGraph().getSqlDialect().createSchemaStatement());
         sql.append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes(this.name));
         if (this.sqlgGraph.getSqlDialect().needsSemicolon()) {
             sql.append(";");

--- a/sqlg-postgres-parent/sqlg-postgres-dialect/src/main/java/org/umlg/sqlg/sql/dialect/PostgresDialect.java
+++ b/sqlg-postgres-parent/sqlg-postgres-dialect/src/main/java/org/umlg/sqlg/sql/dialect/PostgresDialect.java
@@ -3148,7 +3148,6 @@ public class PostgresDialect extends BaseSqlDialect {
 
         private SqlgGraph sqlgGraph;
         private Semaphore semaphore;
-        private boolean canceled;
         /**
          * should we keep running?
          */
@@ -3192,7 +3191,10 @@ public class PostgresDialect extends BaseSqlDialect {
                                 try {
                                     this.sqlgGraph.getTopology().fromNotifyJson(pid, timestamp);
                                 } catch (Exception e) {
-                                    logger.error("Error in Postgresql notification", e);
+                                	// we may get InterruptedException when we shut down
+                                	if (run.get()){
+                                		logger.error("Error in Postgresql notification", e);
+                                	}
                                 } finally {
                                     this.sqlgGraph.tx().rollback();
                                 }

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/schema/TestSchema.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/schema/TestSchema.java
@@ -1,5 +1,17 @@
 package org.umlg.sqlg.test.schema;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.T;
@@ -8,12 +20,6 @@ import org.junit.Test;
 import org.umlg.sqlg.structure.SchemaTable;
 import org.umlg.sqlg.structure.Topology;
 import org.umlg.sqlg.test.BaseTest;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import static org.junit.Assert.*;
 
 /**
  * Date: 2014/08/13
@@ -192,4 +198,22 @@ public class TestSchema extends BaseTest {
     	assertTrue(mgr.getSchema("B").isPresent());
     }
 
+    @Test
+    public void testExistingSchema() throws SQLException{
+    	String schema="A";
+    	Connection c=this.sqlgGraph.tx().getConnection();
+    	try (Statement ps=c.createStatement();){
+    		ps.executeUpdate("create schema "+this.sqlgGraph.getSqlDialect().maybeWrapInQoutes(schema));
+    	}
+    	c.commit();
+    	Topology mgr=this.sqlgGraph.getTopology();
+    	
+    	assertFalse(mgr.getSchema("A").isPresent());
+    	
+    	this.sqlgGraph.addVertex(T.label, schema+".A");
+    	this.sqlgGraph.tx().commit();
+    	assertTrue(mgr.getSchema("A").isPresent());
+    	
+    	
+    }
 }


### PR DESCRIPTION
1.3.3 regression: we did not use the dialect create schema statement in Schema class, so we lost the "if not exists" clause. Fixed + unit tested.