### PR TITLE
Do not fail on concurrency error

### DIFF
--- a/sqlg-postgres-parent/sqlg-postgres-dialect/src/main/java/org/umlg/sqlg/sql/dialect/PostgresDialect.java
+++ b/sqlg-postgres-parent/sqlg-postgres-dialect/src/main/java/org/umlg/sqlg/sql/dialect/PostgresDialect.java
@@ -3222,7 +3222,11 @@ public class PostgresDialect extends BaseSqlDialect {
             //configure the DB to use the standard conforming strings otherwise the escape sequences cause errors
             st.executeUpdate("ALTER DATABASE \"" + dbName + "\" SET standard_conforming_strings TO ON;");
         } catch (SQLException e) {
-            throw new IllegalStateException("Failed to modify the database configuration.");
+        	// ignore concurrency error, probably only works if PostgreSQL uses english
+        	// but the error code is always 0, and the SQLState is "internal error" which is not really helpful
+        	if (!e.getMessage().toLowerCase().contains("tuple concurrently updated")){
+        		throw new IllegalStateException("Failed to modify the database configuration.",e);
+        	}
         }
     }
 


### PR DESCRIPTION
I got that error in work, and the exception wasn't dumped. Turns out it's a concurrency error, so I ignore it. This allows several SqlgGraphs to be opened concurrently, as the new test shows.

We still have other issues. For example, if the table V_Person is not created before we start all the threads, some things will fail randomly. I suppose the notification system is not fast enough for these kind of tests. Some errors are worrying: for example I get an error that an edge does not have the relevant vertex, but my test does not create edges.