### PR TITLE
Support postgresql full text operator as a predicate

### DIFF
--- a/sqlg-core/src/main/java/org/umlg/sqlg/predicate/FullText.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/predicate/FullText.java
@@ -1,0 +1,66 @@
+package org.umlg.sqlg.predicate;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+import java.util.function.BiPredicate;
+
+import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Full text match predicate
+ * This is very postgresql oriented:
+ * - configuration is whatever was used to create the index
+ * - plain is to switch to plainto_tsquery (no need to use operators, etc.)
+ * @author jpmoresmau
+ *
+ */
+public class FullText implements BiPredicate<String, String> {
+	private static Logger logger = LoggerFactory.getLogger(FullText.class.getName());
+	/**
+	 * full text configuration to use
+	 */
+	private String configuration;
+	
+	/**
+	 * plain mode (no operators in query)
+	 */
+	private boolean plain = false;
+	
+	public static P<String> fullTextMatch(String configuration,final String value){
+		return fullTextMatch(configuration,false, value);
+	}
+	
+	public static P<String> fullTextMatch(String configuration, boolean plain, final String value){
+		return new P<>(new FullText(configuration,plain),value);
+	}
+	
+	public FullText(String configuration,boolean plain) {
+		this.configuration = configuration;
+		this.plain = plain;
+	}
+	
+	public String getConfiguration() {
+		return configuration;
+	}
+	
+	public boolean isPlain() {
+		return plain;
+	}
+	
+	@Override
+	public boolean test(String first, String second) {
+		logger.warn("Using Java implementation of FullText search instead of database");
+		Set<String> words1=new HashSet<>(Arrays.asList(first.toLowerCase(Locale.ENGLISH).split("\\s")));
+		Set<String> words2=new HashSet<>(Arrays.asList(second.toLowerCase(Locale.ENGLISH).split("\\s")));
+		return words1.containsAll(words2);
+	}
+
+	@Override
+	public String toString() {
+		return "FullText('"+configuration+"')";
+	}
+}

--- a/sqlg-core/src/main/java/org/umlg/sqlg/predicate/Text.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/predicate/Text.java
@@ -94,34 +94,34 @@ public enum Text implements BiPredicate<String, String> {
     };
 
     public static P<String> contains(final String value) {
-        return new P(Text.contains, value);
+        return new P<>(Text.contains, value);
     }
 
     public static P<String> ncontains(final String value) {
-        return new P(Text.ncontains, value);
+        return new P<>(Text.ncontains, value);
     }
 
     public static P<String> containsCIS(final String value) {
-        return new P(Text.containsCIS, value);
+        return new P<>(Text.containsCIS, value);
     }
 
     public static P<String> ncontainsCIS(final String value) {
-        return new P(Text.ncontainsCIS, value);
+        return new P<>(Text.ncontainsCIS, value);
     }
 
     public static P<String> startsWith(final String value) {
-        return new P(Text.startsWith, value);
+        return new P<>(Text.startsWith, value);
     }
 
     public static P<String> nstartsWith(final String value) {
-        return new P(Text.nstartsWith, value);
+        return new P<>(Text.nstartsWith, value);
     }
 
     public static P<String> endsWith(final String value) {
-        return new P(Text.endsWith, value);
+        return new P<>(Text.endsWith, value);
     }
 
     public static P<String> nendsWith(final String value) {
-        return new P(Text.nendsWith, value);
+        return new P<>(Text.nendsWith, value);
     }
 }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/sql/dialect/SqlDialect.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/sql/dialect/SqlDialect.java
@@ -8,6 +8,7 @@ import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.Range;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.tinkerpop.gremlin.structure.T;
+import org.umlg.sqlg.predicate.FullText;
 import org.umlg.sqlg.structure.PropertyType;
 import org.umlg.sqlg.structure.SchemaTable;
 import org.umlg.sqlg.structure.SqlgGraph;
@@ -427,6 +428,16 @@ public interface SqlDialect {
 
     default boolean requiredPreparedStatementDeallocate() {
         return false;
+    }
+    
+    /**
+     * get the full text query for the given predicate and column
+     * @param fullText
+     * @param column
+     * @return
+     */
+    default String getFullTextQueryText(FullText fullText,String column){
+    	throw new UnsupportedOperationException("FullText search is not supported on this database");
     }
 
 }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/strategy/BaseSqlgStrategy.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/strategy/BaseSqlgStrategy.java
@@ -32,6 +32,7 @@ import org.apache.tinkerpop.gremlin.structure.T;
 import org.javatuples.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.umlg.sqlg.predicate.FullText;
 import org.umlg.sqlg.predicate.Text;
 import org.umlg.sqlg.sql.parse.ReplacedStep;
 import org.umlg.sqlg.structure.SqlgGraph;
@@ -520,14 +521,8 @@ public abstract class BaseSqlgStrategy extends AbstractTraversalStrategy<Travers
     private List<HasContainer> optimizeTextContains(ReplacedStep<?, ?> replacedStep, List<HasContainer> hasContainers) {
         List<HasContainer> result = new ArrayList<>();
         for (HasContainer hasContainer : hasContainers) {
-            if (hasContainer.getBiPredicate() == Text.contains ||
-                    hasContainer.getBiPredicate() == Text.ncontains ||
-                    hasContainer.getBiPredicate() == Text.containsCIS ||
-                    hasContainer.getBiPredicate() == Text.ncontainsCIS ||
-                    hasContainer.getBiPredicate() == Text.startsWith ||
-                    hasContainer.getBiPredicate() == Text.nstartsWith ||
-                    hasContainer.getBiPredicate() == Text.endsWith ||
-                    hasContainer.getBiPredicate() == Text.nendsWith
+            if (hasContainer.getBiPredicate() instanceof Text ||
+                    hasContainer.getBiPredicate() instanceof FullText
                     ) {
                 replacedStep.addHasContainer(hasContainer);
                 result.add(hasContainer);
@@ -539,14 +534,8 @@ public abstract class BaseSqlgStrategy extends AbstractTraversalStrategy<Travers
     private boolean isTextContains(List<HasContainer> hasContainers) {
         return (hasContainers.size() == 1 && !hasContainers.get(0).getKey().equals(T.label.getAccessor()) &&
                 !hasContainers.get(0).getKey().equals(T.id.getAccessor()) &&
-                (hasContainers.get(0).getBiPredicate() == Text.contains ||
-                        hasContainers.get(0).getBiPredicate() == Text.ncontains ||
-                        hasContainers.get(0).getBiPredicate() == Text.containsCIS ||
-                        hasContainers.get(0).getBiPredicate() == Text.ncontainsCIS ||
-                        hasContainers.get(0).getBiPredicate() == Text.startsWith ||
-                        hasContainers.get(0).getBiPredicate() == Text.nstartsWith ||
-                        hasContainers.get(0).getBiPredicate() == Text.endsWith ||
-                        hasContainers.get(0).getBiPredicate() == Text.nendsWith
+                (hasContainers.get(0).getBiPredicate() instanceof Text ||
+                        hasContainers.get(0).getBiPredicate() instanceof FullText
                 ));
     }
 

--- a/sqlg-postgres-parent/sqlg-postgres-dialect/src/main/java/org/umlg/sqlg/sql/dialect/PostgresDialect.java
+++ b/sqlg-postgres-parent/sqlg-postgres-dialect/src/main/java/org/umlg/sqlg/sql/dialect/PostgresDialect.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 import org.umlg.sqlg.gis.GeographyPoint;
 import org.umlg.sqlg.gis.GeographyPolygon;
 import org.umlg.sqlg.gis.Gis;
+import org.umlg.sqlg.predicate.FullText;
 import org.umlg.sqlg.structure.*;
 import org.umlg.sqlg.structure.PropertyType;
 import org.umlg.sqlg.util.SqlgUtil;
@@ -3460,5 +3461,11 @@ public class PostgresDialect extends BaseSqlDialect {
     @Override
     public boolean requiredPreparedStatementDeallocate() {
         return true;
+    }
+    
+    @Override
+    public String getFullTextQueryText(FullText fullText, String column) {
+    	String toQuery=fullText.isPlain()?"plainto_tsquery":"to_tsquery";
+    	return "to_tsvector('"+fullText.getConfiguration()+"', "+column+") @@ "+toQuery+"(?)";
     }
 }

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/gremlincompile/TestGremlinCompileFullTextPredicate.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/gremlincompile/TestGremlinCompileFullTextPredicate.java
@@ -1,0 +1,90 @@
+package org.umlg.sqlg.test.gremlincompile;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import java.beans.PropertyVetoException;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.umlg.sqlg.predicate.FullText;
+import org.umlg.sqlg.structure.SchemaManager;
+import org.umlg.sqlg.test.BaseTest;
+
+/**
+ * test full text support
+ * @author jpmoresmau
+ *
+ */
+public class TestGremlinCompileFullTextPredicate extends BaseTest {
+
+    @BeforeClass
+    public static void beforeClass() throws ClassNotFoundException, IOException, PropertyVetoException {
+        BaseTest.beforeClass();
+        if (configuration.getString("jdbc.url").contains("postgresql")) {
+            configuration.addProperty("distributed", true);
+        }
+    }
+	
+	public TestGremlinCompileFullTextPredicate() {
+		
+	}
+	
+	@Test
+	public void testDefaultImplementation(){
+		FullText ft=new FullText("",true);
+		assertTrue(ft.test("a fat cat sat on a mat and ate a fat rat", "cat"));
+		assertTrue(ft.test("a fat cat sat on a mat and ate a fat rat", "cat rat"));
+		assertFalse(ft.test("a fat cat sat on a mat and ate a fat rat", "cat cow"));
+	}
+	
+	@Test
+	public void testDocExamples() throws SQLException {
+		 assumeTrue(configuration.getString("jdbc.url").contains("postgresql"));
+		 Vertex v0=this.sqlgGraph.addVertex(T.label, "Sentence", "name", "a fat cat sat on a mat and ate a fat rat");
+		 Vertex v1=this.sqlgGraph.addVertex(T.label, "Sentence", "name", "fatal error");
+		 Vertex v2=this.sqlgGraph.addVertex(T.label, "Sentence", "name", "error is not fatal");
+		 
+		 
+		 this.sqlgGraph.tx().commit();
+		 try (Statement s=this.sqlgGraph.tx().getConnection().createStatement();){
+			 String create="CREATE INDEX sentence_idx ON \""+SchemaManager.VERTEX_PREFIX+"Sentence\" USING GIN (to_tsvector('english', name))";
+			 s.execute(create);
+		 }
+		 this.sqlgGraph.tx().commit();
+		 
+		 List<Vertex> vts=this.sqlgGraph.traversal().V().hasLabel("Sentence").has("name",FullText.fullTextMatch("english", "fat & rat")).toList();
+		 assertEquals(1,vts.size());
+		 assertTrue(vts.contains(v0));
+		 vts=this.sqlgGraph.traversal().V().hasLabel("Sentence").has("name",FullText.fullTextMatch("english", "fat & cow")).toList();
+		 assertEquals(0,vts.size());
+		 
+		 vts=this.sqlgGraph.traversal().V().hasLabel("Sentence").has("name",FullText.fullTextMatch("english", "fatal <-> error")).toList();
+		 assertEquals(1,vts.size());
+		 assertTrue(vts.contains(v1));
+		 
+		 vts=this.sqlgGraph.traversal().V().hasLabel("Sentence").has("name",FullText.fullTextMatch("english", "fatal & error")).toList();
+		 assertEquals(2,vts.size());
+		 assertTrue(vts.contains(v1));
+		 assertTrue(vts.contains(v2));
+		 
+		 vts=this.sqlgGraph.traversal().V().hasLabel("Sentence").has("name",FullText.fullTextMatch("english",true, "fatal error")).toList();
+		 assertEquals(2,vts.size());
+		 assertTrue(vts.contains(v1));
+		 assertTrue(vts.contains(v2));
+		 
+		 vts=this.sqlgGraph.traversal().V().hasLabel("Sentence").has("name",FullText.fullTextMatch("english", "!cat")).toList();
+		 assertEquals(2,vts.size());
+		 assertTrue(vts.contains(v1));
+		 assertTrue(vts.contains(v2));
+	}
+
+}

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/gremlincompile/TestGremlinCompileFullTextPredicate.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/gremlincompile/TestGremlinCompileFullTextPredicate.java
@@ -33,10 +33,7 @@ public class TestGremlinCompileFullTextPredicate extends BaseTest {
             configuration.addProperty("distributed", true);
         }
     }
-	
-	public TestGremlinCompileFullTextPredicate() {
-		
-	}
+
 	
 	@Test
 	public void testDefaultImplementation(){


### PR DESCRIPTION
Addresses #163 by providing a FullText class that can be used as a predicate. Using this on another DB than postgresql will fail. I've looked at H2 full text support and it's quite involved (you run the query separately, which gives you back a query to let you select the matching rows) and really not easy to integrate, whereas PostgreSQL seems trivial. I'll test that more extensively at work.