### PR TITLE
Support older syntax

### DIFF
--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/IndexType.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/IndexType.java
@@ -100,6 +100,16 @@ public class IndexType {
 	}
 	
 	public static IndexType fromNotifyJson(JsonNode node){
+		// older version
+		if(node.isValueNode()){
+			String s=node.asText();
+			if ("UNIQUE".equalsIgnoreCase(s)){
+				return UNIQUE;
+			} else if ("NON_UNIQUE".equalsIgnoreCase(s)){
+				return NON_UNIQUE;
+			}
+		}
+		
 		IndexType it=new IndexType(node.get("name").asText());
 		Iterator<String> keys=node.fieldNames();
 		while (keys.hasNext()){

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/index/TestIndex.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/index/TestIndex.java
@@ -9,6 +9,8 @@ import org.junit.Test;
 import org.umlg.sqlg.structure.*;
 import org.umlg.sqlg.test.BaseTest;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -310,4 +312,17 @@ public class TestIndex extends BaseTest {
         this.sqlgGraph.tx().commit();
     }
 
+    @Test
+    public void testIndexTypeFromJSON() throws Exception {
+    	IndexType it1=IndexType.fromNotifyJson(new ObjectMapper().readTree("{\"name\":\"UNIQUE\"}"));
+    	Assert.assertEquals(IndexType.UNIQUE, it1);
+    	IndexType it2=IndexType.fromNotifyJson(new ObjectMapper().readTree("\"UNIQUE\""));
+    	Assert.assertEquals(IndexType.UNIQUE, it2);
+    	
+    	it1=IndexType.fromNotifyJson(new ObjectMapper().readTree("{\"name\":\"NON_UNIQUE\"}"));
+    	Assert.assertEquals(IndexType.NON_UNIQUE, it1);
+    	it2=IndexType.fromNotifyJson(new ObjectMapper().readTree("\"NON_UNIQUE\""));
+    	Assert.assertEquals(IndexType.NON_UNIQUE, it2);
+    	
+    }
 }


### PR DESCRIPTION
When I introduced the support for other indices, I broke getting the index type from the old json format, this adds it back, hopefully simplifies migration (I saw this error when upgrading)