### PR TITLE
public SqlgIoRegistry to resolve access problem with gremlin-server

### DIFF
--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgIoRegistry.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgIoRegistry.java
@@ -8,7 +8,7 @@ import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoIo;
  * Date: 2015/05/07
  * Time: 8:05 PM
  */
-class SqlgIoRegistry extends AbstractIoRegistry {
+public class SqlgIoRegistry extends AbstractIoRegistry {
 
     private static final SqlgIoRegistry INSTANCE = new SqlgIoRegistry();
 


### PR DESCRIPTION
By default, SqlgIoRegistry is package private, which creates problem while registering it for java-driver. I get following exception
```Could not establish serializer - java.lang.IllegalAccessException: Class org.apache.tinkerpop.gremlin.driver.ser.AbstractMessageSerializer can not access a member of class org.umlg.sqlg.structure.SqlgIoRegistry with modifiers "private"``` 

I have simply changed class visibility to public and issue was solved