### PR TITLE
Feature/137 topology update

### DIFF
--- a/sqlg-core/src/main/java/org/umlg/sqlg/sql/dialect/SqlDialect.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/sql/dialect/SqlDialect.java
@@ -269,7 +269,7 @@ public interface SqlDialect {
      * @return the statement head to create a schema
      */
     default String createSchemaStatement() {
-        return "CREATE SCHEMA ";
+        return "CREATE SCHEMA IF NOT EXISTS ";
     }
 
     default void prepareDB(Connection conn) {

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/AbstractLabel.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/AbstractLabel.java
@@ -116,6 +116,11 @@ public abstract class AbstractLabel implements TopologyInf {
     public String getName() {
         return this.label;
     }
+    
+    
+    public String getFullName(){
+    	return getSchema().getName()+"."+getName();
+    }
 
     public Map<String, PropertyColumn> getProperties() {
         Map<String, PropertyColumn> result = new HashMap<>();
@@ -479,4 +484,5 @@ public abstract class AbstractLabel implements TopologyInf {
     		this.getSchema().getTopology().fire(idx, "", TopologyChangeAction.DELETE);
     	}
     }
+
 }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/AbstractLabel.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/AbstractLabel.java
@@ -385,7 +385,7 @@ public abstract class AbstractLabel implements TopologyInf {
             for (JsonNode propertyNode : removedPropertyArrayNode) {
             	String pName=propertyNode.asText();
             	PropertyColumn old=this.properties.remove(pName);
-                if (fire && old==null){
+                if (fire && old!=null){
                 	this.getSchema().getTopology().fire(old, "", TopologyChangeAction.DELETE);
                 }
             }
@@ -403,7 +403,7 @@ public abstract class AbstractLabel implements TopologyInf {
             for (JsonNode indexNode : removedIndexArrayNode) {
             	String iName=indexNode.asText();
             	Index old=this.indexes.remove(iName);
-                if (fire && old==null){
+                if (fire && old!=null){
                 	this.getSchema().getTopology().fire(old, "", TopologyChangeAction.DELETE);
                 }
             }
@@ -451,7 +451,9 @@ public abstract class AbstractLabel implements TopologyInf {
         sql.append(sqlgGraph.getSqlDialect().maybeWrapInQoutes(table));
         sql.append(" DROP COLUMN IF EXISTS ");
         sql.append(sqlgGraph.getSqlDialect().maybeWrapInQoutes(column));
-        sql.append(" CASCADE");
+        if (sqlgGraph.getSqlDialect().supportsCascade()){
+        	sql.append(" CASCADE");
+        }
         if (sqlgGraph.getSqlDialect().needsSemicolon()) {
             sql.append(";");
         }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/AbstractLabel.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/AbstractLabel.java
@@ -442,10 +442,6 @@ public abstract class AbstractLabel implements TopologyInf {
 
     protected abstract String getPrefix();
     
-    @Override
-    public void remove(boolean preserveData) {
-    	throw new UnsupportedOperationException();
-    }
     
     abstract void removeProperty(PropertyColumn propertyColumn,boolean preserveData);
 

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/AbstractLabel.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/AbstractLabel.java
@@ -458,9 +458,6 @@ public abstract class AbstractLabel implements TopologyInf {
         if (logger.isDebugEnabled()) {
             logger.debug(sql.toString());
         }
-        if (logger.isDebugEnabled()) {
-            logger.debug(sql.toString());
-        }
         Connection conn = sqlgGraph.tx().getConnection();
         try (Statement stmt = conn.createStatement()) {
             stmt.execute(sql.toString());

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/AbstractLabel.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/AbstractLabel.java
@@ -442,9 +442,19 @@ public abstract class AbstractLabel implements TopologyInf {
 
     protected abstract String getPrefix();
     
-    
+    /**
+     * remove a given property
+     * @param propertyColumn the property column
+     * @param preserveData should we preserve the SQL data?
+     */
     abstract void removeProperty(PropertyColumn propertyColumn,boolean preserveData);
 
+    /**
+     * remove a column from the table
+     * @param schema the schema
+     * @param table the table name
+     * @param column the column name
+     */
     void removeColumn(String schema, String table,String column){
     	StringBuilder sql = new StringBuilder("ALTER TABLE ");
         sql.append(sqlgGraph.getSqlDialect().maybeWrapInQoutes(schema));
@@ -469,6 +479,11 @@ public abstract class AbstractLabel implements TopologyInf {
         }
     }
     
+    /**
+     * remove a given index that was on this label
+     * @param idx  the index
+     * @param preserveData should we keep the SQL data
+     */
     void removeIndex(Index idx,boolean preserveData){
     	this.getSchema().getTopology().lock();
     	if (!uncommittedRemovedIndexes.contains(idx.getName())){

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/EdgeLabel.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/EdgeLabel.java
@@ -437,7 +437,7 @@ public class EdgeLabel extends AbstractLabel {
             return false;
         }
         EdgeLabel otherEdgeLabel = (EdgeLabel) other;
-        if (this.getSchema().getTopology().isWriteLockHeldByCurrentThread()) {
+        if (this.getSchema().getTopology().isWriteLockHeldByCurrentThread() && !this.uncommittedInVertexLabels.isEmpty()) {
             VertexLabel vertexLabel = this.uncommittedOutVertexLabels.iterator().next();
             VertexLabel otherVertexLabel = otherEdgeLabel.uncommittedOutVertexLabels.iterator().next();
             return vertexLabel.getSchema().equals(otherVertexLabel.getSchema()) && otherEdgeLabel.getLabel().equals(this.getLabel());
@@ -537,7 +537,8 @@ public class EdgeLabel extends AbstractLabel {
             edgeLabelNode.set("uncommittedProperties", abstractLabelNode.get().get("uncommittedProperties"));
             edgeLabelNode.set("uncommittedIndexes", abstractLabelNode.get().get("uncommittedIndexes"));
             edgeLabelNode.set("uncommittedRemovedProperties", abstractLabelNode.get().get("uncommittedRemovedProperties"));
-        }
+            edgeLabelNode.set("uncommittedRemovedIndexes", abstractLabelNode.get().get("uncommittedRemovedIndexes"));
+          }
 
         if (this.getSchema().getTopology().isWriteLockHeldByCurrentThread() && !this.uncommittedOutVertexLabels.isEmpty()) {
             foundSomething = true;

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/EdgeLabel.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/EdgeLabel.java
@@ -312,10 +312,14 @@ public class EdgeLabel extends AbstractLabel {
         return result;
     }
 
+    boolean isValid(){
+    	return this.outVertexLabels.size()>0 || this.uncommittedOutVertexLabels.size()>0;
+    }
+    
     public Set<VertexLabel> getOutVertexLabels() {
         Set<VertexLabel> result = new HashSet<>();
         result.addAll(this.outVertexLabels);
-        if (this.getSchema().getTopology().isWriteLockHeldByCurrentThread()) {
+        if (isValid() && this.getSchema().getTopology().isWriteLockHeldByCurrentThread()) {
             result.addAll(this.uncommittedOutVertexLabels);
            	result.removeAll(this.uncommittedRemovedOutVertexLabels);
         }
@@ -325,7 +329,7 @@ public class EdgeLabel extends AbstractLabel {
     public Set<VertexLabel> getInVertexLabels() {
         Set<VertexLabel> result = new HashSet<>();
         result.addAll(this.inVertexLabels);
-        if (this.getSchema().getTopology().isWriteLockHeldByCurrentThread()) {
+        if (isValid() && this.getSchema().getTopology().isWriteLockHeldByCurrentThread()) {
             result.addAll(this.uncommittedInVertexLabels);
         	result.removeAll(this.uncommittedInVertexLabels);
         }
@@ -687,7 +691,7 @@ public class EdgeLabel extends AbstractLabel {
     
     @Override
     public void remove(boolean preserveData) {
-    	getSchema().removeEdge(this,preserveData);
+    	getSchema().removeEdgeLabel(this,preserveData);
     }
     
     void delete(){

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/EdgeLabel.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/EdgeLabel.java
@@ -331,7 +331,7 @@ public class EdgeLabel extends AbstractLabel {
         result.addAll(this.inVertexLabels);
         if (isValid() && this.getSchema().getTopology().isWriteLockHeldByCurrentThread()) {
             result.addAll(this.uncommittedInVertexLabels);
-        	result.removeAll(this.uncommittedInVertexLabels);
+        	result.removeAll(this.uncommittedRemovedInVertexLabels);
         }
         return Collections.unmodifiableSet(result);
     }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/EdgeLabel.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/EdgeLabel.java
@@ -699,6 +699,9 @@ public class EdgeLabel extends AbstractLabel {
     	getSchema().removeEdgeLabel(this,preserveData);
     }
     
+    /**
+     * delete the table
+     */
     void delete(){
     	 String schema = getSchema().getName();
          String tableName = EDGE_PREFIX + getLabel();
@@ -726,10 +729,19 @@ public class EdgeLabel extends AbstractLabel {
          }
     }
     
+    /**
+     * delete a given column from the table
+     * @param column
+     */
     void deleteColumn(String column){
     	removeColumn(getSchema().getName(),  EDGE_PREFIX + getLabel(), column);
     }
     
+    /**
+     * remove a vertex label from the out collection
+     * @param lbl the vertex label
+     * @param preserveData should we keep the sql data?
+     */
     void removeOutVertexLabel(VertexLabel lbl,boolean preserveData){
     	this.uncommittedRemovedOutVertexLabels.add(lbl);
     	if (!preserveData){
@@ -737,6 +749,11 @@ public class EdgeLabel extends AbstractLabel {
     	}
     }
     
+    /**
+     * remove a vertex label from the in collection
+     * @param lbl the vertex label
+     * @param preserveData should we keep the sql data?
+     */
     void removeInVertexLabel(VertexLabel lbl,boolean preserveData){
     	this.uncommittedRemovedInVertexLabels.add(lbl);
     	if (!preserveData){

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/EdgeLabel.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/EdgeLabel.java
@@ -599,4 +599,35 @@ public class EdgeLabel extends AbstractLabel {
     		this.getSchema().getTopology().fire(propertyColumn, "", TopologyChangeAction.DELETE);
     	}
     }
+    
+    @Override
+    public void remove(boolean preserveData) {
+    	getSchema().removeEdge(this,preserveData);
+    }
+    
+    void delete(){
+    	 String schema = getSchema().getName();
+         String tableName = EDGE_PREFIX + getLabel();
+
+         SqlDialect sqlDialect = this.sqlgGraph.getSqlDialect();
+         sqlDialect.assertTableName(tableName);
+         StringBuilder sql = new StringBuilder("DROP TABLE IF EXISTS ");
+         sql.append(sqlDialect.maybeWrapInQoutes(schema));
+         sql.append(".");
+         sql.append(sqlDialect.maybeWrapInQoutes(tableName));
+         sql.append(" CASCADE");
+         if (logger.isDebugEnabled()) {
+             logger.debug(sql.toString());
+         }
+         Connection conn = sqlgGraph.tx().getConnection();
+         try (Statement stmt = conn.createStatement()) {
+             stmt.execute(sql.toString());
+         } catch (SQLException e) {
+             throw new RuntimeException(e);
+         }
+    }
+    
+    public String getFullName(){
+    	return getSchema().getName()+"."+getName();
+    }
 }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/EdgeLabel.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/EdgeLabel.java
@@ -615,9 +615,14 @@ public class EdgeLabel extends AbstractLabel {
          sql.append(sqlDialect.maybeWrapInQoutes(schema));
          sql.append(".");
          sql.append(sqlDialect.maybeWrapInQoutes(tableName));
-         sql.append(" CASCADE");
+         if (sqlDialect.supportsCascade()){
+        	 sql.append(" CASCADE");
+         }
          if (logger.isDebugEnabled()) {
              logger.debug(sql.toString());
+         }
+         if (sqlDialect.needsSemicolon()) {
+             sql.append(";");
          }
          Connection conn = sqlgGraph.tx().getConnection();
          try (Statement stmt = conn.createStatement()) {

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/EdgeLabel.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/EdgeLabel.java
@@ -504,15 +504,18 @@ public class EdgeLabel extends AbstractLabel {
             return false;
         }
         EdgeLabel otherEdgeLabel = (EdgeLabel) other;
-        if (this.getSchema().getTopology().isWriteLockHeldByCurrentThread() && !this.uncommittedInVertexLabels.isEmpty()) {
-            VertexLabel vertexLabel = this.uncommittedOutVertexLabels.iterator().next();
-            VertexLabel otherVertexLabel = otherEdgeLabel.uncommittedOutVertexLabels.iterator().next();
-            return vertexLabel.getSchema().equals(otherVertexLabel.getSchema()) && otherEdgeLabel.getLabel().equals(this.getLabel());
-        } else {
-            VertexLabel vertexLabel = this.outVertexLabels.iterator().next();
-            VertexLabel otherVertexLabel = otherEdgeLabel.outVertexLabels.iterator().next();
-            return vertexLabel.getSchema().equals(otherVertexLabel.getSchema()) && otherEdgeLabel.getLabel().equals(this.getLabel());
+        if (isValid()){
+	        if (this.getSchema().getTopology().isWriteLockHeldByCurrentThread() && !this.uncommittedInVertexLabels.isEmpty()) {
+	            VertexLabel vertexLabel = this.uncommittedOutVertexLabels.iterator().next();
+	            VertexLabel otherVertexLabel = otherEdgeLabel.uncommittedOutVertexLabels.iterator().next();
+	            return vertexLabel.getSchema().equals(otherVertexLabel.getSchema()) && otherEdgeLabel.getLabel().equals(this.getLabel());
+	        } else {
+	            VertexLabel vertexLabel = this.outVertexLabels.iterator().next();
+	            VertexLabel otherVertexLabel = otherEdgeLabel.outVertexLabels.iterator().next();
+	            return vertexLabel.getSchema().equals(otherVertexLabel.getSchema()) && otherEdgeLabel.getLabel().equals(this.getLabel());
+	        }
         }
+        return otherEdgeLabel.getLabel().equals(this.getLabel());
     }
 
     boolean deepEquals(EdgeLabel otherEdgeLabel) {
@@ -549,7 +552,9 @@ public class EdgeLabel extends AbstractLabel {
     @Override
     protected JsonNode toJson() {
         ObjectNode edgeLabelNode = new ObjectNode(Topology.OBJECT_MAPPER.getNodeFactory());
-        edgeLabelNode.put("schema", getSchema().getName());
+        if (isValid()){
+        	edgeLabelNode.put("schema", getSchema().getName());
+        }
         edgeLabelNode.put("label", getLabel());
         edgeLabelNode.set("properties", super.toJson());
 
@@ -569,7 +574,7 @@ public class EdgeLabel extends AbstractLabel {
         }
         edgeLabelNode.set("inVertexLabels", inVertexLabelArrayNode);
 
-        if (this.getSchema().getTopology().isWriteLockHeldByCurrentThread()) {
+        if (isValid() && this.getSchema().getTopology().isWriteLockHeldByCurrentThread()) {
             outVertexLabelArrayNode = new ArrayNode(Topology.OBJECT_MAPPER.getNodeFactory());
             for (VertexLabel outVertexLabel : this.uncommittedOutVertexLabels) {
                 ObjectNode outVertexLabelObjectNode = new ObjectNode(Topology.OBJECT_MAPPER.getNodeFactory());

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/EdgeRole.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/EdgeRole.java
@@ -101,6 +101,8 @@ public class EdgeRole implements TopologyInf {
 				break;
 			case OUT: dir="->";
 				break;
+			default: dir="unknown";
+				break;
 		}
 		return vertexLabel.getName()+dir+edgeLabel.getName();
 	}

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/EdgeRole.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/EdgeRole.java
@@ -8,11 +8,23 @@ import org.apache.tinkerpop.gremlin.structure.Direction;
  *
  */
 public class EdgeRole implements TopologyInf {
+	/**
+	 * the vertex label
+	 */
 	private VertexLabel vertexLabel;
+	/**
+	 * the edge label
+	 */
 	private EdgeLabel edgeLabel;
 	
+	/**
+	 * the direction of the edge for the vertex label
+	 */
 	private Direction direction;
 	
+	/**
+	 * are we committed or still in a transaction?
+	 */
 	private boolean committed;
 	
 	EdgeRole(VertexLabel vertexLabel, EdgeLabel edgeLabel, Direction direction, boolean committed) {

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/EdgeRole.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/EdgeRole.java
@@ -1,0 +1,100 @@
+package org.umlg.sqlg.structure;
+
+import org.apache.tinkerpop.gremlin.structure.Direction;
+
+/**
+ * Represent a pair VertexLabel and EdgeLabel
+ * @author jpmoresmau
+ *
+ */
+public class EdgeRole implements TopologyInf {
+	private VertexLabel vertexLabel;
+	private EdgeLabel edgeLabel;
+	
+	private Direction direction;
+	
+	private boolean committed;
+	
+	EdgeRole(VertexLabel vertexLabel, EdgeLabel edgeLabel, Direction direction, boolean committed) {
+		super();
+		this.vertexLabel = vertexLabel;
+		this.edgeLabel = edgeLabel;
+		this.direction = direction;
+		this.committed = committed;
+	}
+
+	public VertexLabel getVertexLabel() {
+		return vertexLabel;
+	}
+
+	public EdgeLabel getEdgeLabel() {
+		return edgeLabel;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((direction == null) ? 0 : direction.hashCode());
+		result = prime * result + ((edgeLabel == null) ? 0 : edgeLabel.hashCode());
+		result = prime * result + ((vertexLabel == null) ? 0 : vertexLabel.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		EdgeRole other = (EdgeRole) obj;
+		if (direction != other.direction)
+			return false;
+		if (edgeLabel == null) {
+			if (other.edgeLabel != null)
+				return false;
+		} else if (!edgeLabel.equals(other.edgeLabel))
+			return false;
+		if (vertexLabel == null) {
+			if (other.vertexLabel != null)
+				return false;
+		} else if (!vertexLabel.equals(other.vertexLabel))
+			return false;
+		return true;
+	}
+
+	public Direction getDirection() {
+		return direction;
+	}
+
+	@Override
+	public boolean isCommitted() {
+		return committed;
+	}
+	
+	@Override
+	public void remove(boolean preserveData) {
+		getVertexLabel().removeEdgeRole(this, preserveData);
+	}
+	
+	@Override
+	public String getName() {
+		String dir="";
+		switch (direction){
+			case BOTH: dir="<->";
+				break;
+			case IN: dir="<-";
+				break;
+			case OUT: dir="->";
+				break;
+		}
+		return vertexLabel.getName()+dir+edgeLabel.getName();
+	}
+	
+	@Override
+	public String toString() {
+		return getName();
+	}
+}

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/GlobalUniqueIndex.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/GlobalUniqueIndex.java
@@ -166,4 +166,10 @@ public class GlobalUniqueIndex implements TopologyInf {
     public String toString() {
         return toJson().toString();
     }
+    
+    
+    @Override
+    public void remove(boolean preserveData) {
+    	throw new UnsupportedOperationException();
+    }
 }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/GlobalUniqueIndex.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/GlobalUniqueIndex.java
@@ -112,7 +112,7 @@ public class GlobalUniqueIndex implements TopologyInf {
         vertexLabel.ensureIndexExists(IndexType.UNIQUE, Collections.singletonList(valuePropertyColumn));
         vertexLabel.ensureIndexExists(IndexType.UNIQUE, Arrays.asList(recordIdColumn, propertyColumn));
         GlobalUniqueIndex globalUniqueIndex = new GlobalUniqueIndex(topology, globalUniqueIndexName, properties);
-        topology.addToUncommittedGlobalUniqueIndexes(globalUniqueIndex);
+        topology.getGlobalUniqueIndexSchema().globalUniqueIndexes.put(globalUniqueIndex.getName(),globalUniqueIndex);
         TopologyManager.addGlobalUniqueIndex(sqlgGraph, globalUniqueIndexName, properties);
         globalUniqueIndex.committed = false;
         return globalUniqueIndex;
@@ -170,6 +170,6 @@ public class GlobalUniqueIndex implements TopologyInf {
     
     @Override
     public void remove(boolean preserveData) {
-    	throw new UnsupportedOperationException();
+    	topology.getGlobalUniqueIndexSchema().removeGlobalUniqueIndex(this,preserveData);
     }
 }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/Index.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/Index.java
@@ -266,6 +266,9 @@ public class Index implements TopologyInf {
          sql.append(sqlDialect.maybeWrapInQoutes(getParentLabel().getSchema().getName()));
          sql.append(".");
          sql.append(sqlDialect.maybeWrapInQoutes(getName()));
+         if (sqlDialect.needsSemicolon()) {
+             sql.append(";");
+         }
          if (logger.isDebugEnabled()) {
              logger.debug(sql.toString());
          }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/Index.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/Index.java
@@ -245,4 +245,10 @@ public class Index implements TopologyInf {
     public AbstractLabel getParentLabel() {
 		return abstractLabel;
 	}
+    
+    
+    @Override
+    public void remove(boolean preserveData) {
+    	throw new UnsupportedOperationException();
+    }
 }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/Index.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/Index.java
@@ -223,7 +223,7 @@ public class Index implements TopologyInf {
         Index index = new Index(indexName, indexType, abstractLabel, properties);
         SchemaTable schemaTable = SchemaTable.of(abstractLabel.getSchema().getName(), abstractLabel.getLabel());
         index.addIndex(sqlgGraph, schemaTable, indexName, indexType, properties);
-        TopologyManager.addIndex(sqlgGraph, index);
+        TopologyManager.addIndex(sqlgGraph, index,  properties);
         index.committed = false;
         return index;
     }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/PropertyColumn.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/PropertyColumn.java
@@ -132,4 +132,10 @@ public class PropertyColumn implements TopologyInf {
     public String toString() {
         return this.abstractLabel.getSchema().getName() + "." + this.abstractLabel.getLabel() + "." + this.name;
     }
+    
+    
+    @Override
+    public void remove(boolean preserveData) {
+    	this.abstractLabel.removeProperty(this, preserveData);
+    }
 }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/Schema.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/Schema.java
@@ -356,7 +356,8 @@ public class Schema implements TopologyInf {
         for (Map.Entry<String, VertexLabel> vertexLabelEntry : this.vertexLabels.entrySet()) {
             String vertexQualifiedName = this.name + "." + VERTEX_PREFIX + vertexLabelEntry.getValue().getLabel();
             Map<String, PropertyColumn> uncommittedPropertyColumnMap = vertexLabelEntry.getValue().getUncommittedPropertyTypeMap();
-            if (!uncommittedPropertyColumnMap.isEmpty()) {
+            Set<String> uncommittedRemovedProperties = vertexLabelEntry.getValue().getUncommittedRemovedProperties();
+            if (!uncommittedPropertyColumnMap.isEmpty() || !uncommittedRemovedProperties.isEmpty()) {
                 result.put(vertexQualifiedName, vertexLabelEntry.getValue());
             }
         }
@@ -1107,4 +1108,9 @@ public class Schema implements TopologyInf {
         return validationErrors;
     }
 
+    
+    @Override
+    public void remove(boolean preserveData) {
+    	throw new UnsupportedOperationException();
+    }
 }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/Schema.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/Schema.java
@@ -1305,6 +1305,11 @@ public class Schema implements TopologyInf {
     	getTopology().removeSchema(this, preserveData);
     }
     
+    /**
+     * remove a given edge label
+     * @param edgeLabel the edge label
+     * @param preserveData should we keep the SQL data
+     */
     void removeEdgeLabel(EdgeLabel edgeLabel,boolean preserveData){
     	getTopology().lock();
     	String fn=this.name + "." + EDGE_PREFIX + edgeLabel.getName();
@@ -1326,6 +1331,11 @@ public class Schema implements TopologyInf {
     	}
     }
     
+    /**
+     * remove a given vertex label
+     * @param vertexLabel the vertex label
+     * @param preserveData should we keep the SQL data
+     */
     void removeVertexLabel(VertexLabel vertexLabel, boolean preserveData){
     	getTopology().lock();
     	String fn=this.name + "." + VERTEX_PREFIX + vertexLabel.getName();
@@ -1346,6 +1356,11 @@ public class Schema implements TopologyInf {
     	
     }
     
+    /**
+     * remove the given global unique index
+     * @param index the index to remove
+     * @param preserveData should we keep the sql data?
+     */
     void removeGlobalUniqueIndex(GlobalUniqueIndex index,boolean preserveData){
     	getTopology().lock();
     	String fn=index.getName();
@@ -1360,6 +1375,9 @@ public class Schema implements TopologyInf {
     	}
     }
     
+    /**
+     * delete schema in DB
+     */
     void delete(){
         StringBuilder sql = new StringBuilder();
         sql.append("DROP SCHEMA ");

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/Topology.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/Topology.java
@@ -326,8 +326,8 @@ public class Topology {
         sqlgSchema.getVertexLabels().values().forEach((v) -> {
             SchemaTable vertexLabelSchemaTable = SchemaTable.of(v.getSchema().getName(), VERTEX_PREFIX + v.getLabel());
             this.schemaTableForeignKeyCache.put(vertexLabelSchemaTable, Pair.of(new HashSet<>(), new HashSet<>()));
-            v.getInEdgeLabels().forEach((edgeLabelName, edgeLabel) -> this.schemaTableForeignKeyCache.get(vertexLabelSchemaTable).getLeft().add(SchemaTable.of(edgeLabel.getSchema().getName(), SchemaManager.EDGE_PREFIX + edgeLabel.getLabel())));
-            v.getOutEdgeLabels().forEach((edgeLabelName, edgeLabel) -> this.schemaTableForeignKeyCache.get(vertexLabelSchemaTable).getRight().add(SchemaTable.of(v.getSchema().getName(), SchemaManager.EDGE_PREFIX + edgeLabel.getLabel())));
+            v.getInEdgeLabels().forEach((edgeLabelName, edgeLabel) -> this.schemaTableForeignKeyCache.get(vertexLabelSchemaTable).getLeft().add(SchemaTable.of(edgeLabel.getSchema().getName(), EDGE_PREFIX + edgeLabel.getLabel())));
+            v.getOutEdgeLabels().forEach((edgeLabelName, edgeLabel) -> this.schemaTableForeignKeyCache.get(vertexLabelSchemaTable).getRight().add(SchemaTable.of(v.getSchema().getName(), EDGE_PREFIX + edgeLabel.getLabel())));
         });
 
         this.edgeForeignKeyCache = sqlgSchema.getAllEdgeForeignKeys();
@@ -1376,7 +1376,7 @@ public class Topology {
                 if (f instanceof AbstractLabel) {
                     AbstractLabel abstractLabel = (AbstractLabel) f;
                     Schema schema = abstractLabel.getSchema();
-                    result.remove(schema.getName() + "." + (abstractLabel instanceof VertexLabel ? SchemaManager.VERTEX_PREFIX : SchemaManager.EDGE_PREFIX) + abstractLabel.getLabel());
+                    result.remove(schema.getName() + "." + (abstractLabel instanceof VertexLabel ? VERTEX_PREFIX : EDGE_PREFIX) + abstractLabel.getLabel());
                 }
             }
             return Collections.unmodifiableMap(result);
@@ -1393,7 +1393,7 @@ public class Topology {
                 if (f instanceof AbstractLabel) {
                     AbstractLabel abstractLabel = (AbstractLabel) f;
                     Schema schema = abstractLabel.getSchema();
-                    String key = schema.getName() + "." + (abstractLabel instanceof VertexLabel ? SchemaManager.VERTEX_PREFIX : SchemaManager.EDGE_PREFIX) + abstractLabel.getLabel();
+                    String key = schema.getName() + "." + (abstractLabel instanceof VertexLabel ? VERTEX_PREFIX : EDGE_PREFIX) + abstractLabel.getLabel();
                     Map<String, PropertyType> tmp = this.allTableCache.get(key);
                     result.put(key, tmp);
                 } else if (f instanceof GlobalUniqueIndex) {
@@ -1580,14 +1580,14 @@ public class Topology {
      * @param edgeLabel
      */
     void addOutForeignKeysToVertexLabel(VertexLabel vertexLabel, EdgeLabel edgeLabel) {
-        SchemaTable schemaTable = SchemaTable.of(vertexLabel.getSchema().getName(), SchemaManager.VERTEX_PREFIX + vertexLabel.getLabel());
+        SchemaTable schemaTable = SchemaTable.of(vertexLabel.getSchema().getName(), VERTEX_PREFIX + vertexLabel.getLabel());
         Pair<Set<SchemaTable>, Set<SchemaTable>> foreignKeys = this.schemaTableForeignKeyCache.get(schemaTable);
         if (foreignKeys == null) {
             foreignKeys = Pair.of(new HashSet<>(), new HashSet<>());
             this.schemaTableForeignKeyCache.put(schemaTable, foreignKeys);
 
         }
-        foreignKeys.getRight().add(SchemaTable.of(vertexLabel.getSchema().getName(), SchemaManager.EDGE_PREFIX + edgeLabel.getLabel()));
+        foreignKeys.getRight().add(SchemaTable.of(vertexLabel.getSchema().getName(), EDGE_PREFIX + edgeLabel.getLabel()));
     }
 
     /**
@@ -1596,13 +1596,13 @@ public class Topology {
      * @param edgeLabel
      */
     void addInForeignKeysToVertexLabel(VertexLabel vertexLabel, EdgeLabel edgeLabel) {
-        SchemaTable schemaTable = SchemaTable.of(vertexLabel.getSchema().getName(), SchemaManager.VERTEX_PREFIX + vertexLabel.getLabel());
+        SchemaTable schemaTable = SchemaTable.of(vertexLabel.getSchema().getName(), VERTEX_PREFIX + vertexLabel.getLabel());
         Pair<Set<SchemaTable>, Set<SchemaTable>> foreignKeys = this.schemaTableForeignKeyCache.get(schemaTable);
         if (foreignKeys == null) {
             foreignKeys = Pair.of(new HashSet<>(), new HashSet<>());
             this.schemaTableForeignKeyCache.put(schemaTable, foreignKeys);
         }
-        foreignKeys.getLeft().add(SchemaTable.of(edgeLabel.getSchema().getName(), SchemaManager.EDGE_PREFIX + edgeLabel.getLabel()));
+        foreignKeys.getLeft().add(SchemaTable.of(edgeLabel.getSchema().getName(), EDGE_PREFIX + edgeLabel.getLabel()));
     }
 
     /**
@@ -1611,10 +1611,10 @@ public class Topology {
      * @param edgeLabel
      */
     void removeOutForeignKeysFromVertexLabel(VertexLabel vertexLabel, EdgeLabel edgeLabel) {
-        SchemaTable schemaTable = SchemaTable.of(vertexLabel.getSchema().getName(), SchemaManager.VERTEX_PREFIX + vertexLabel.getLabel());
+        SchemaTable schemaTable = SchemaTable.of(vertexLabel.getSchema().getName(), VERTEX_PREFIX + vertexLabel.getLabel());
         Pair<Set<SchemaTable>, Set<SchemaTable>> foreignKeys = this.schemaTableForeignKeyCache.get(schemaTable);
         if (foreignKeys != null) {
-         	foreignKeys.getRight().remove(SchemaTable.of(vertexLabel.getSchema().getName(), SchemaManager.EDGE_PREFIX + edgeLabel.getLabel()));
+         	foreignKeys.getRight().remove(SchemaTable.of(vertexLabel.getSchema().getName(), EDGE_PREFIX + edgeLabel.getLabel()));
         }
     }
 
@@ -1624,10 +1624,10 @@ public class Topology {
      * @param edgeLabel
      */
     void removeInForeignKeysFromVertexLabel(VertexLabel vertexLabel, EdgeLabel edgeLabel) {
-        SchemaTable schemaTable = SchemaTable.of(vertexLabel.getSchema().getName(), SchemaManager.VERTEX_PREFIX + vertexLabel.getLabel());
+        SchemaTable schemaTable = SchemaTable.of(vertexLabel.getSchema().getName(), VERTEX_PREFIX + vertexLabel.getLabel());
         Pair<Set<SchemaTable>, Set<SchemaTable>> foreignKeys = this.schemaTableForeignKeyCache.get(schemaTable);
         if (foreignKeys != null && edgeLabel.isValid()) {
-            foreignKeys.getLeft().remove(SchemaTable.of(edgeLabel.getSchema().getName(), SchemaManager.EDGE_PREFIX + edgeLabel.getLabel()));
+            foreignKeys.getLeft().remove(SchemaTable.of(edgeLabel.getSchema().getName(), EDGE_PREFIX + edgeLabel.getLabel()));
         }
     }
     

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/Topology.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/Topology.java
@@ -709,12 +709,8 @@ public class Topology {
             for (Map.Entry<String, AbstractLabel> stringMapEntry : uncommittedAllTables.entrySet()) {
                 String uncommittedSchemaTable = stringMapEntry.getKey();
                 AbstractLabel abstractLabel = stringMapEntry.getValue();
-                Map<String, PropertyType> committedProperties = this.allTableCache.get(uncommittedSchemaTable);
-                if (committedProperties != null) {
-                    committedProperties.putAll(abstractLabel.getPropertyTypeMap());
-                } else {
-                    this.allTableCache.put(uncommittedSchemaTable, abstractLabel.getPropertyTypeMap());
-                }
+                // we replace the whole map since getPropertyTypeMap() gives the full map, and we may have removed properties
+                this.allTableCache.put(uncommittedSchemaTable, abstractLabel.getPropertyTypeMap());
             }
 
             Map<SchemaTable, Pair<Set<SchemaTable>, Set<SchemaTable>>> uncommittedSchemaTableForeignKeys = getUncommittedSchemaTableForeignKeys();

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/Topology.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/Topology.java
@@ -1582,9 +1582,26 @@ public class Topology {
     void removeInForeignKeysFromVertexLabel(VertexLabel vertexLabel, EdgeLabel edgeLabel) {
         SchemaTable schemaTable = SchemaTable.of(vertexLabel.getSchema().getName(), SchemaManager.VERTEX_PREFIX + vertexLabel.getLabel());
         Pair<Set<SchemaTable>, Set<SchemaTable>> foreignKeys = this.schemaTableForeignKeyCache.get(schemaTable);
-        if (foreignKeys != null) {
+        if (foreignKeys != null && edgeLabel.isValid()) {
             foreignKeys.getLeft().remove(SchemaTable.of(edgeLabel.getSchema().getName(), SchemaManager.EDGE_PREFIX + edgeLabel.getLabel()));
         }
+    }
+    
+    void removeVertexLabel(VertexLabel vertexLabel){
+    	SchemaTable schemaTable = SchemaTable.of(vertexLabel.getSchema().getName(), SchemaManager.VERTEX_PREFIX + vertexLabel.getLabel());
+    	this.schemaTableForeignKeyCache.remove(schemaTable);
+    	for (EdgeLabel lbl:vertexLabel.getOutEdgeLabels().values()){
+    		removeFromEdgeForeignKeyCache(
+                lbl.getSchema().getName() + "." + EDGE_PREFIX + lbl.getLabel(),
+                vertexLabel.getSchema().getName() + "." + vertexLabel.getLabel() + SchemaManager.OUT_VERTEX_COLUMN_END);
+    	}
+    	for (EdgeLabel lbl:vertexLabel.getInEdgeLabels().values()){
+    		if (lbl.isValid()){
+    			removeFromEdgeForeignKeyCache(
+    					lbl.getSchema().getName() + "." + EDGE_PREFIX + lbl.getLabel(),
+    					vertexLabel.getSchema().getName() + "." + vertexLabel.getLabel() + SchemaManager.IN_VERTEX_COLUMN_END);
+    		}
+    	}
     }
     
     void addToUncommittedGlobalUniqueIndexes(GlobalUniqueIndex globalUniqueIndex) {

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/Topology.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/Topology.java
@@ -1529,6 +1529,16 @@ public class Topology {
             foreignKeys.add(foreignKey);
         }
     }
+    
+    void removeFromEdgeForeignKeyCache(String name, String foreignKey) {
+        Set<String> foreignKeys = this.edgeForeignKeyCache.get(name);
+        if (foreignKeys != null) {
+            foreignKeys.remove(foreignKey);
+        }
+        if (foreignKeys.isEmpty()){
+        	this.edgeForeignKeyCache.remove(name);
+        }
+    }
 
     void addToAllTables(String tableName, Map<String, PropertyType> propertyTypeMap) {
         this.allTableCache.put(tableName, propertyTypeMap);
@@ -1561,6 +1571,22 @@ public class Topology {
         foreignKeys.getLeft().add(SchemaTable.of(edgeLabel.getSchema().getName(), SchemaManager.EDGE_PREFIX + edgeLabel.getLabel()));
     }
 
+    void removeOutForeignKeysFromVertexLabel(VertexLabel vertexLabel, EdgeLabel edgeLabel) {
+        SchemaTable schemaTable = SchemaTable.of(vertexLabel.getSchema().getName(), SchemaManager.VERTEX_PREFIX + vertexLabel.getLabel());
+        Pair<Set<SchemaTable>, Set<SchemaTable>> foreignKeys = this.schemaTableForeignKeyCache.get(schemaTable);
+        if (foreignKeys != null) {
+         	foreignKeys.getRight().remove(SchemaTable.of(vertexLabel.getSchema().getName(), SchemaManager.EDGE_PREFIX + edgeLabel.getLabel()));
+        }
+    }
+
+    void removeInForeignKeysFromVertexLabel(VertexLabel vertexLabel, EdgeLabel edgeLabel) {
+        SchemaTable schemaTable = SchemaTable.of(vertexLabel.getSchema().getName(), SchemaManager.VERTEX_PREFIX + vertexLabel.getLabel());
+        Pair<Set<SchemaTable>, Set<SchemaTable>> foreignKeys = this.schemaTableForeignKeyCache.get(schemaTable);
+        if (foreignKeys != null) {
+            foreignKeys.getLeft().remove(SchemaTable.of(edgeLabel.getSchema().getName(), SchemaManager.EDGE_PREFIX + edgeLabel.getLabel()));
+        }
+    }
+    
     void addToUncommittedGlobalUniqueIndexes(GlobalUniqueIndex globalUniqueIndex) {
         this.uncommittedGlobalUniqueIndexes.add(globalUniqueIndex);
     }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/TopologyChangeAction.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/TopologyChangeAction.java
@@ -5,5 +5,7 @@ package org.umlg.sqlg.structure;
  */
 public enum TopologyChangeAction {
     CREATE,
-    ADD_IN_VERTEX_LABELTO_EDGE;
+    ADD_IN_VERTEX_LABELTO_EDGE,
+    DELETE;
+	
 }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/TopologyInf.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/TopologyInf.java
@@ -13,4 +13,5 @@ public interface TopologyInf {
 
     String getName();
 
+    void remove(boolean preserveData);
 }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/TopologyInf.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/TopologyInf.java
@@ -13,5 +13,9 @@ public interface TopologyInf {
 
     String getName();
 
+    /**
+     * remove the topology item
+     * @param preserveData if true we don't delete at the SQL level
+     */
     void remove(boolean preserveData);
 }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/TopologyManager.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/TopologyManager.java
@@ -138,6 +138,34 @@ public class TopologyManager {
         }
     }
 
+    public static void removeEdgeLabel(SqlgGraph sqlgGraph, EdgeLabel edge){
+    	 BatchManager.BatchModeType batchModeType = flushAndSetTxToNone(sqlgGraph);
+         try {
+             GraphTraversalSource traversalSource = sqlgGraph.topology();
+             List<Vertex> edges=
+	             traversalSource.V()
+		          	.hasLabel(SQLG_SCHEMA + "." + SQLG_SCHEMA_SCHEMA)
+		          	.has("name", edge.getSchema().getName())
+		         	.out(SQLG_SCHEMA_SCHEMA_VERTEX_EDGE)
+		         	.out(SQLG_SCHEMA_OUT_EDGES_EDGE)
+		         	.has("name",edge.getName()).toList();
+	         if (edges.size()>0){
+	        	 Vertex edgeV=edges.get(0);
+             
+	        	 traversalSource.V(edgeV)
+	             	.out(SQLG_SCHEMA_EDGE_PROPERTIES_EDGE)
+	             	.drop()
+            		.iterate();
+	        	 traversalSource.V(edgeV)
+	             	.drop()
+	             	.iterate();
+	         }
+             	
+         } finally {
+             sqlgGraph.tx().batchMode(batchModeType);
+         }
+    }
+    
     public static void addLabelToEdge(SqlgGraph sqlgGraph, String schema, String prefixedTable, boolean in, SchemaTable foreignKey) {
         BatchManager.BatchModeType batchModeType = flushAndSetTxToNone(sqlgGraph);
         try {

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/TopologyManager.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/TopologyManager.java
@@ -425,7 +425,7 @@ public class TopologyManager {
 
     }
 
-    public static void addIndex(SqlgGraph sqlgGraph, Index index) {
+    public static void addIndex(SqlgGraph sqlgGraph, Index index, List<PropertyColumn> properties) {
         BatchManager.BatchModeType batchModeType = flushAndSetTxToNone(sqlgGraph);
         try {
             //get the abstractLabel's vertex
@@ -466,7 +466,7 @@ public class TopologyManager {
             } else {
                 abstractLabelVertex.addEdge(SQLG_SCHEMA_EDGE_INDEX_EDGE, indexVertex);
             }
-            for (PropertyColumn property : index.getProperties()) {
+            for (PropertyColumn property : properties) {
                 List<Vertex> propertyVertexes = traversalSource.V(abstractLabelVertex)
                         .out(abstractLabel instanceof VertexLabel ? SQLG_SCHEMA_VERTEX_PROPERTIES_EDGE : SQLG_SCHEMA_EDGE_PROPERTIES_EDGE)
                         .has("name", property.getName())

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/TopologyManager.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/TopologyManager.java
@@ -601,6 +601,30 @@ public class TopologyManager {
             sqlgGraph.tx().batchMode(batchModeType);
         }
     }
+    
+    static void removeGlobalUniqueIndex(SqlgGraph sqlgGraph, String globalUniqueIndexName) {
+        BatchManager.BatchModeType batchModeType = flushAndSetTxToNone(sqlgGraph);
+        try {
+            GraphTraversalSource traversalSource = sqlgGraph.topology();
+            List<Vertex> uniquePropertyConstraints = traversalSource.V()
+                    .hasLabel(SQLG_SCHEMA + "." + SQLG_SCHEMA_GLOBAL_UNIQUE_INDEX)
+                    .has("name", globalUniqueIndexName)
+                    .toList();
+            if (uniquePropertyConstraints.size() > 0) {
+            	traversalSource.V(uniquePropertyConstraints.get(0))
+            		.out(SQLG_SCHEMA_GLOBAL_UNIQUE_INDEX_PROPERTY_EDGE)
+            		.drop()
+            		.iterate();
+            	traversalSource.V(uniquePropertyConstraints.get(0))
+        			.drop()
+        			.iterate();
+            }
+            
+        } finally {
+            sqlgGraph.tx().batchMode(batchModeType);
+        }
+    }
+    
 
     private static BatchManager.BatchModeType flushAndSetTxToNone(SqlgGraph sqlgGraph) {
         //topology elements can not be added in batch mode because on flushing the topology

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/TopologyManager.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/TopologyManager.java
@@ -425,7 +425,7 @@ public class TopologyManager {
 
     }
 
-    public static void addIndex(SqlgGraph sqlgGraph, Index index, List<PropertyColumn> properties) {
+    public static void addIndex(SqlgGraph sqlgGraph, Index index) {
         BatchManager.BatchModeType batchModeType = flushAndSetTxToNone(sqlgGraph);
         try {
             //get the abstractLabel's vertex
@@ -466,7 +466,7 @@ public class TopologyManager {
             } else {
                 abstractLabelVertex.addEdge(SQLG_SCHEMA_EDGE_INDEX_EDGE, indexVertex);
             }
-            for (PropertyColumn property : properties) {
+            for (PropertyColumn property : index.getProperties()) {
                 List<Vertex> propertyVertexes = traversalSource.V(abstractLabelVertex)
                         .out(abstractLabel instanceof VertexLabel ? SQLG_SCHEMA_VERTEX_PROPERTIES_EDGE : SQLG_SCHEMA_EDGE_PROPERTIES_EDGE)
                         .has("name", property.getName())

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/VertexLabel.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/VertexLabel.java
@@ -615,6 +615,8 @@ public class VertexLabel extends AbstractLabel {
         			case ROLE:
         				this.getSchema().getTopology().fire(new EdgeRole(this, lbl,Direction.OUT,true), "", TopologyChangeAction.DELETE);
         				break;
+        			default:
+        				break;
         			}
         			
         		}

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/VertexLabel.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/VertexLabel.java
@@ -403,6 +403,7 @@ public class VertexLabel extends AbstractLabel {
             vertexLabelNode.set("uncommittedProperties", abstractLabelNode.get().get("uncommittedProperties"));
             vertexLabelNode.set("uncommittedIndexes", abstractLabelNode.get().get("uncommittedIndexes"));
             vertexLabelNode.set("uncommittedRemovedProperties", abstractLabelNode.get().get("uncommittedRemovedProperties"));
+            vertexLabelNode.set("uncommittedRemovedIndexes", abstractLabelNode.get().get("uncommittedRemovedIndexes"));
         }
 
         if (this.getSchema().getTopology().isWriteLockHeldByCurrentThread() && !this.uncommittedOutEdgeLabels.isEmpty()) {

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/VertexLabel.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/VertexLabel.java
@@ -788,6 +788,8 @@ public class VertexLabel extends AbstractLabel {
 		case OUT:
 			ers=er.getEdgeLabel().getOutVertexLabels();
 			break;
+		default:
+			throw new IllegalStateException("Unknown direction!");
     	}
     	if (!ers.contains(this)){
     		throw new IllegalStateException("Trying to remove a EdgeRole from a non owner VertexLabel");

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/VertexLabel.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/VertexLabel.java
@@ -766,6 +766,11 @@ public class VertexLabel extends AbstractLabel {
     	uncommittedRemovedInEdgeLabels.put(lbl.getFullName(),EdgeRemoveType.LABEL);
     }
     
+    /**
+     * remove a given edge role
+     * @param er the edge role
+     * @param preserveData should we keep the SQL data
+     */
     void removeEdgeRole(EdgeRole er, boolean preserveData){
     	if (er.getVertexLabel()!=this){
     		throw new IllegalStateException("Trying to remove a EdgeRole from a non owner VertexLabel");
@@ -813,6 +818,9 @@ public class VertexLabel extends AbstractLabel {
     	this.getSchema().removeVertexLabel(this, preserveData);
     }
     
+    /**
+     * delete the table
+     */
     void delete(){
    	 String schema = getSchema().getName();
         String tableName = VERTEX_PREFIX + getLabel();

--- a/sqlg-test/src/main/java/org/umlg/sqlg/AllTest.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/AllTest.java
@@ -26,6 +26,7 @@ import org.umlg.sqlg.test.remove.TestRemoveEdge;
 import org.umlg.sqlg.test.rollback.TestRollback;
 import org.umlg.sqlg.test.schema.*;
 import org.umlg.sqlg.test.topology.TestTopologyChangeListener;
+import org.umlg.sqlg.test.topology.TestTopologyDelete;
 import org.umlg.sqlg.test.topology.TestTopologyMultipleGraphs;
 import org.umlg.sqlg.test.topology.TestTopologyUpgrade;
 import org.umlg.sqlg.test.topology.TestValidateTopology;
@@ -167,7 +168,8 @@ import org.umlg.sqlg.test.vertexstep.localvertexstep.*;
         TestSqlgSchema.class,
         TestValidateTopology.class,
         TestBatchNormalUpdateDateTimeArrays.class,
-        TestTopologyChangeListener.class
+        TestTopologyChangeListener.class,
+        TestTopologyDelete.class
 })
 public class AllTest {
 }

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/schema/TestLoadSchemaViaNotify.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/schema/TestLoadSchemaViaNotify.java
@@ -430,9 +430,9 @@ public class TestLoadSchemaViaNotify extends BaseTest {
 	         assertEquals("", topologyListenerTriple.get(4).getMiddle());
 	         assertEquals(TopologyChangeAction.CREATE, topologyListenerTriple.get(4).getRight());
     
-	         assertEquals(globalUniqueIndex, topologyListenerTriple.get(8).getLeft());
-	         assertEquals("", topologyListenerTriple.get(8).getMiddle());
-	         assertEquals(TopologyChangeAction.CREATE, topologyListenerTriple.get(8).getRight());
+	         assertEquals(globalUniqueIndex, topologyListenerTriple.get(5).getLeft());
+	         assertEquals("", topologyListenerTriple.get(5).getMiddle());
+	         assertEquals(TopologyChangeAction.CREATE, topologyListenerTriple.get(5).getRight());
     	}
     }
 }

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/topology/TestTopologyChangeListener.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/topology/TestTopologyChangeListener.java
@@ -113,6 +113,10 @@ public class TestTopologyChangeListener extends BaseTest {
 			super();
 			this.topologyListenerTriple = topologyListenerTriple;
 		}
+        
+        public TopologyListenerTest(){
+        	
+        }
 
 		@Override
         public void change(TopologyInf topologyInf, String oldValue, TopologyChangeAction action) {
@@ -123,5 +127,22 @@ public class TestTopologyChangeListener extends BaseTest {
                     Triple.of(topologyInf, oldValue, action)
             );
         }
+		
+		public List<Triple<TopologyInf, String, TopologyChangeAction>> getTopologyListenerTriple() {
+			return topologyListenerTriple;
+		}
+		
+		public boolean receivedEvent(TopologyInf topologyInf, TopologyChangeAction action){
+			for (Triple<TopologyInf, String, TopologyChangeAction> t:topologyListenerTriple){
+				if (t.getLeft().equals(topologyInf) && t.getRight().equals(action)){
+					return true;
+				}
+			}
+			return false;
+		}
+		
+		public void reset(){
+			topologyListenerTriple.clear();
+		}
     }
 }

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/topology/TestTopologyDelete.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/topology/TestTopologyDelete.java
@@ -10,6 +10,8 @@ import static org.umlg.sqlg.structure.Topology.SQLG_SCHEMA;
 import static org.umlg.sqlg.structure.Topology.SQLG_SCHEMA_EDGE_INDEX_EDGE;
 import static org.umlg.sqlg.structure.Topology.SQLG_SCHEMA_EDGE_LABEL_NAME;
 import static org.umlg.sqlg.structure.Topology.SQLG_SCHEMA_EDGE_PROPERTIES_EDGE;
+import static org.umlg.sqlg.structure.Topology.SQLG_SCHEMA_GLOBAL_UNIQUE_INDEX;
+import static org.umlg.sqlg.structure.Topology.SQLG_SCHEMA_GLOBAL_UNIQUE_INDEX_PROPERTY_EDGE;
 import static org.umlg.sqlg.structure.Topology.SQLG_SCHEMA_INDEX_NAME;
 import static org.umlg.sqlg.structure.Topology.SQLG_SCHEMA_OUT_EDGES_EDGE;
 import static org.umlg.sqlg.structure.Topology.SQLG_SCHEMA_PROPERTY_NAME;
@@ -25,6 +27,10 @@ import java.net.URL;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -40,9 +46,12 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.umlg.sqlg.structure.EdgeLabel;
 import org.umlg.sqlg.structure.EdgeRole;
+import org.umlg.sqlg.structure.GlobalUniqueIndex;
 import org.umlg.sqlg.structure.Index;
 import org.umlg.sqlg.structure.IndexType;
 import org.umlg.sqlg.structure.PropertyColumn;
+import org.umlg.sqlg.structure.PropertyType;
+import org.umlg.sqlg.structure.Schema;
 import org.umlg.sqlg.structure.SchemaManager;
 import org.umlg.sqlg.structure.SqlgGraph;
 import org.umlg.sqlg.structure.Topology;
@@ -194,6 +203,8 @@ public class TestTopologyDelete extends BaseTest {
 			assertFalse(a1.property("p1").isPresent());
 			assertFalse(a1.property("p2").isPresent());
 			*/
+			TopologyListenerTest tlt1=new TopologyListenerTest();
+			sqlgGraph1.getTopology().registerListener(tlt1);
 			this.sqlgGraph.tx().commit();
 			checkPropertyExistenceAfterDeletion(this.sqlgGraph,schema);
 			
@@ -203,6 +214,9 @@ public class TestTopologyDelete extends BaseTest {
 		
 			Thread.sleep(1_000);
 			checkPropertyExistenceAfterDeletion(sqlgGraph1,schema);
+			assertTrue(tlt1.receivedEvent(p1, TopologyChangeAction.DELETE));
+			assertTrue(tlt1.receivedEvent(p2, TopologyChangeAction.DELETE));
+			
 		}
 	}
 	
@@ -253,11 +267,13 @@ public class TestTopologyDelete extends BaseTest {
 	
 
 	@Test
+	
 	public void testDeleteEdgePropertySchema() throws Exception {
 		testDeleteEdgeProperty("MySchema");
 	}
 	
 	@Test
+	
 	public void testDeleteEdgePropertyNoSchema() throws Exception {
 		testDeleteEdgeProperty(this.sqlgGraph.getSqlDialect().getPublicSchema());
 	}
@@ -298,6 +314,8 @@ public class TestTopologyDelete extends BaseTest {
 			assertFalse(a1.property("p1").isPresent());
 			assertFalse(a1.property("p2").isPresent());
 			*/
+			TopologyListenerTest tlt1=new TopologyListenerTest();
+			sqlgGraph1.getTopology().registerListener(tlt1);
 			this.sqlgGraph.tx().commit();
 			checkEdgePropertyExistenceAfterDeletion(this.sqlgGraph,schema);
 			
@@ -308,6 +326,8 @@ public class TestTopologyDelete extends BaseTest {
 			
 			Thread.sleep(1_000);
 			checkEdgePropertyExistenceAfterDeletion(sqlgGraph1,schema);
+			assertTrue(tlt1.receivedEvent(p1, TopologyChangeAction.DELETE));
+			assertTrue(tlt1.receivedEvent(p2, TopologyChangeAction.DELETE));
 		}
 	}
 	
@@ -388,12 +408,18 @@ public class TestTopologyDelete extends BaseTest {
 			assertTrue(tlt.receivedEvent(i2, TopologyChangeAction.DELETE));
 			
 			checkIndexExistenceAfterDeletion(this.sqlgGraph,schema,i1,i2);
+			TopologyListenerTest tlt1=new TopologyListenerTest();
+			sqlgGraph1.getTopology().registerListener(tlt1);
+			
+			
 			this.sqlgGraph.tx().commit();
 			checkIndexExistenceAfterDeletion(this.sqlgGraph,schema,i1,i2);
 			
 			
 			Thread.sleep(1_000);
 			checkIndexExistenceAfterDeletion(sqlgGraph1,schema,i1,i2);
+			assertTrue(tlt1.receivedEvent(i1, TopologyChangeAction.DELETE));
+			assertTrue(tlt1.receivedEvent(i2, TopologyChangeAction.DELETE));
 		}
 	}
 	
@@ -481,12 +507,17 @@ public class TestTopologyDelete extends BaseTest {
 			assertTrue(tlt.receivedEvent(i2, TopologyChangeAction.DELETE));
 			
 			checkEdgeIndexExistenceAfterDeletion(this.sqlgGraph,schema,i1,i2);
+			TopologyListenerTest tlt1=new TopologyListenerTest();
+			sqlgGraph1.getTopology().registerListener(tlt1);
+			
 			this.sqlgGraph.tx().commit();
 			checkEdgeIndexExistenceAfterDeletion(this.sqlgGraph,schema,i1,i2);
 			
 			
 			Thread.sleep(1_000);
 			checkEdgeIndexExistenceAfterDeletion(sqlgGraph1,schema,i1,i2);
+			assertTrue(tlt1.receivedEvent(i1, TopologyChangeAction.DELETE));
+			assertTrue(tlt1.receivedEvent(i2, TopologyChangeAction.DELETE));
 		}
 	}
 	
@@ -589,12 +620,16 @@ public class TestTopologyDelete extends BaseTest {
 			assertTrue(tlt.receivedEvent(e2, TopologyChangeAction.DELETE));
 			
 			checkEdgeExistenceAfterDeletion(this.sqlgGraph,schema);
+			TopologyListenerTest tlt1=new TopologyListenerTest();
+			sqlgGraph1.getTopology().registerListener(tlt1);
 			this.sqlgGraph.tx().commit();
 			checkEdgeExistenceAfterDeletion(this.sqlgGraph,schema);
 			
 			
 			Thread.sleep(1_000);
 			checkEdgeExistenceAfterDeletion(sqlgGraph1,schema);
+			assertTrue(tlt1.receivedEvent(e1, TopologyChangeAction.DELETE));
+			assertTrue(tlt1.receivedEvent(e2, TopologyChangeAction.DELETE));
 		}
 	}
 	
@@ -832,11 +867,13 @@ public class TestTopologyDelete extends BaseTest {
 	}
 	
 	@Test
+	
 	public void testDeleteVertexLabelSchema() throws Exception {
 		testDeleteVertexLabel("MySchema");
 	}
 	
 	@Test
+	
 	public void testDeleteVertexLabelNoSchema() throws Exception {
 		testDeleteVertexLabel(sqlgGraph.getSqlDialect().getPublicSchema());
 	}
@@ -885,10 +922,139 @@ public class TestTopologyDelete extends BaseTest {
 			assertTrue(tlt.receivedEvent(lblb, TopologyChangeAction.DELETE));
 			
 			assertFalse(sqlgGraph.getTopology().getEdgeLabel(schema, "E").isPresent());
+			
+			TopologyListenerTest tlt1=new TopologyListenerTest();
+			sqlgGraph1.getTopology().registerListener(tlt1);
+				
 			sqlgGraph.tx().commit();
 			assertFalse(sqlgGraph.getTopology().getEdgeLabel(schema, "E").isPresent());
 			Thread.sleep(1_000);
 			assertFalse(sqlgGraph1.getTopology().getEdgeLabel(schema, "E").isPresent());
+			assertTrue(tlt1.receivedEvent(lblb, TopologyChangeAction.DELETE));
+			
+		}
+	}
+	
+	private void checkGlobalUniqueIndexBeforeDeletion(SqlgGraph g,String schema,GlobalUniqueIndex gui1,GlobalUniqueIndex gui2) throws Exception {
+		Set<GlobalUniqueIndex> guis=g.getTopology().getGlobalUniqueIndexes();
+		assertNotNull(guis);
+		assertEquals(2,guis.size());
+		assertTrue(guis.contains(gui1));
+		assertTrue(guis.contains(gui2));
+		
+		Map<String,GlobalUniqueIndex> mguis=g.getTopology().getGlobalUniqueIndexSchema().getGlobalUniqueIndexes();
+		assertNotNull(mguis);
+		assertEquals(2,mguis.size());
+		assertTrue(mguis.containsKey(gui1.getName()));
+		assertTrue(mguis.containsKey(gui2.getName()));
+		String name1=gui1.getName();
+		assertEquals(1,g.topology().V().has(SQLG_SCHEMA + "." + SQLG_SCHEMA_GLOBAL_UNIQUE_INDEX,
+                    "name",name1 ).count().next().longValue());
+                    
+		assertEquals(2,g.topology().V().has(SQLG_SCHEMA + "." + SQLG_SCHEMA_GLOBAL_UNIQUE_INDEX,
+                "name",name1 ).out(SQLG_SCHEMA_GLOBAL_UNIQUE_INDEX_PROPERTY_EDGE).count().next().longValue());
+		assertEquals(1,g.topology().V().has(SQLG_SCHEMA + "." + SQLG_SCHEMA_GLOBAL_UNIQUE_INDEX,
+                "name",name1 ).out(SQLG_SCHEMA_GLOBAL_UNIQUE_INDEX_PROPERTY_EDGE)
+				.has("name","name1").count().next().longValue());
+    
+		assertTrue(tableExistsInSQL(Schema.GLOBAL_UNIQUE_INDEX_SCHEMA, VERTEX_PREFIX+name1));
+	
+		String name2=gui2.getName();
+		assertEquals(1,g.topology().V().has(SQLG_SCHEMA + "." + SQLG_SCHEMA_GLOBAL_UNIQUE_INDEX,
+                    "name",name2 ).count().next().longValue());
+                    
+		assertEquals(2,g.topology().V().has(SQLG_SCHEMA + "." + SQLG_SCHEMA_GLOBAL_UNIQUE_INDEX,
+                "name",name2 ).out(SQLG_SCHEMA_GLOBAL_UNIQUE_INDEX_PROPERTY_EDGE).count().next().longValue());
+		assertEquals(1,g.topology().V().has(SQLG_SCHEMA + "." + SQLG_SCHEMA_GLOBAL_UNIQUE_INDEX,
+                "name",name2 ).out(SQLG_SCHEMA_GLOBAL_UNIQUE_INDEX_PROPERTY_EDGE)
+				.has("name","name1").count().next().longValue());
+    
+		assertTrue(tableExistsInSQL(Schema.GLOBAL_UNIQUE_INDEX_SCHEMA, VERTEX_PREFIX+name2));
+	}
+	
+	private void checkGlobalUniqueIndexAfterDeletion(SqlgGraph g,String schema,GlobalUniqueIndex gui1,GlobalUniqueIndex gui2) throws Exception {
+		String name1=gui1.getName();
+		String name2=gui2.getName();
+		
+		Set<GlobalUniqueIndex> guis=g.getTopology().getGlobalUniqueIndexes();
+		assertNotNull(guis);
+		assertEquals(0,guis.size());
+		Map<String,GlobalUniqueIndex> mguis=g.getTopology().getGlobalUniqueIndexSchema().getGlobalUniqueIndexes();
+		assertNotNull(mguis);
+		assertEquals(0,mguis.size());
+		assertEquals(0,g.topology().V().has(SQLG_SCHEMA + "." + SQLG_SCHEMA_GLOBAL_UNIQUE_INDEX,
+                    "name",name1 ).count().next().longValue());
+                    
+		assertEquals(0,g.topology().V().has(SQLG_SCHEMA + "." + SQLG_SCHEMA_GLOBAL_UNIQUE_INDEX,
+                "name",name1 ).out(SQLG_SCHEMA_GLOBAL_UNIQUE_INDEX_PROPERTY_EDGE).count().next().longValue());
+		assertEquals(0,g.topology().V().has(SQLG_SCHEMA + "." + SQLG_SCHEMA_GLOBAL_UNIQUE_INDEX,
+                "name",name1 ).out(SQLG_SCHEMA_GLOBAL_UNIQUE_INDEX_PROPERTY_EDGE)
+				.has("name","name1").count().next().longValue());
+    
+		assertFalse(tableExistsInSQL(Schema.GLOBAL_UNIQUE_INDEX_SCHEMA, VERTEX_PREFIX+name1));
+	
+		assertEquals(0,g.topology().V().has(SQLG_SCHEMA + "." + SQLG_SCHEMA_GLOBAL_UNIQUE_INDEX,
+                    "name",name2 ).count().next().longValue());
+                    
+		assertEquals(0,g.topology().V().has(SQLG_SCHEMA + "." + SQLG_SCHEMA_GLOBAL_UNIQUE_INDEX,
+                "name",name2 ).out(SQLG_SCHEMA_GLOBAL_UNIQUE_INDEX_PROPERTY_EDGE).count().next().longValue());
+		assertEquals(0,g.topology().V().has(SQLG_SCHEMA + "." + SQLG_SCHEMA_GLOBAL_UNIQUE_INDEX,
+                "name",name2 ).out(SQLG_SCHEMA_GLOBAL_UNIQUE_INDEX_PROPERTY_EDGE)
+				.has("name","name1").count().next().longValue());
+    
+		assertTrue(tableExistsInSQL(Schema.GLOBAL_UNIQUE_INDEX_SCHEMA, VERTEX_PREFIX+name2));
+	}
+	
+	@Test
+	public void testDeleteGlobalUniqueIndexSchema() throws Exception {
+		testDeleteGlobalUniqueIndex("MySchema");
+	}
+	
+	private void testDeleteGlobalUniqueIndex(String schema) throws Exception {
+		try (SqlgGraph sqlgGraph1 = SqlgGraph.open(configuration)) {
+		    Map<String, PropertyType> properties = new HashMap<>();
+	        properties.put("name1", PropertyType.STRING);
+	        properties.put("name2", PropertyType.STRING);
+	        
+	        VertexLabel aVertexLabel = this.sqlgGraph.getTopology().getPublicSchema().ensureVertexLabelExist("A", properties);
+	        assertTrue(aVertexLabel.isUncommitted());
+	        Set<PropertyColumn> globalUniqueIndexPropertyColumns = new HashSet<>();
+	        globalUniqueIndexPropertyColumns.addAll(new HashSet<>(aVertexLabel.getProperties().values()));
+	        GlobalUniqueIndex gui1=this.sqlgGraph.getTopology().ensureGlobalUniqueIndexExist(globalUniqueIndexPropertyColumns);
+	        
+	        VertexLabel bVertexLabel = this.sqlgGraph.getTopology().getPublicSchema().ensureVertexLabelExist("B", properties);
+	        assertTrue(bVertexLabel.isUncommitted());
+	        globalUniqueIndexPropertyColumns = new HashSet<>();
+	        globalUniqueIndexPropertyColumns.addAll(new HashSet<>(bVertexLabel.getProperties().values()));
+	        GlobalUniqueIndex gui2=this.sqlgGraph.getTopology().ensureGlobalUniqueIndexExist(globalUniqueIndexPropertyColumns);
+	        
+	        checkGlobalUniqueIndexBeforeDeletion(this.sqlgGraph,schema,gui1,gui2);
+	        this.sqlgGraph.tx().commit();
+	        checkGlobalUniqueIndexBeforeDeletion(this.sqlgGraph,schema,gui1,gui2);
+	        Thread.sleep(1_000);
+	        checkGlobalUniqueIndexBeforeDeletion(sqlgGraph1,schema,gui1,gui2);
+	        
+	        TopologyListenerTest tlt=new TopologyListenerTest();
+			this.sqlgGraph.getTopology().registerListener(tlt);
+	        
+	        gui1.remove(false);
+	        assertTrue(tlt.receivedEvent(gui1, TopologyChangeAction.DELETE));
+	        
+	        gui2.remove(true);
+	        assertTrue(tlt.receivedEvent(gui2, TopologyChangeAction.DELETE));
+	        
+	        checkGlobalUniqueIndexAfterDeletion(this.sqlgGraph,schema,gui1,gui2);
+	        
+	        TopologyListenerTest tlt1=new TopologyListenerTest();
+			sqlgGraph1.getTopology().registerListener(tlt1);
+	        
+	        this.sqlgGraph.tx().commit();
+	        checkGlobalUniqueIndexAfterDeletion(this.sqlgGraph,schema,gui1,gui2);
+	        Thread.sleep(1_000);
+	        checkGlobalUniqueIndexAfterDeletion(sqlgGraph1,schema,gui1,gui2);
+	        assertTrue(tlt1.receivedEvent(gui1, TopologyChangeAction.DELETE));
+	        assertTrue(tlt1.receivedEvent(gui2, TopologyChangeAction.DELETE));
+	       
 		}
 	}
 }

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/topology/TestTopologyDelete.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/topology/TestTopologyDelete.java
@@ -34,7 +34,6 @@ import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Assume;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.umlg.sqlg.structure.EdgeLabel;
 import org.umlg.sqlg.structure.Index;
@@ -144,13 +143,11 @@ public class TestTopologyDelete extends BaseTest {
 	
 	
 	@Test
-	@Ignore
 	public void testDeleteVertexPropertySchema() throws Exception {
 		testDeleteVertexProperty("MySchema");
 	}
 	
 	@Test
-	@Ignore
 	public void testDeleteVertexPropertyNoSchema() throws Exception {
 		testDeleteVertexProperty(this.sqlgGraph.getSqlDialect().getPublicSchema());
 	}
@@ -249,13 +246,11 @@ public class TestTopologyDelete extends BaseTest {
 	
 
 	@Test
-	@Ignore
 	public void testDeleteEdgePropertySchema() throws Exception {
 		testDeleteEdgeProperty("MySchema");
 	}
 	
 	@Test
-	@Ignore
 	public void testDeleteEdgePropertyNoSchema() throws Exception {
 		testDeleteEdgeProperty(this.sqlgGraph.getSqlDialect().getPublicSchema());
 	}
@@ -350,13 +345,11 @@ public class TestTopologyDelete extends BaseTest {
 	}
 	
 	@Test
-	@Ignore
 	public void testDeleteVertexIndexSchema() throws Exception {
 		testDeleteVertexIndex("MySchema");
 	}
 	
 	@Test
-	@Ignore
 	public void testDeleteVertexIndexNoSchema() throws Exception {
 		testDeleteVertexIndex(this.sqlgGraph.getSqlDialect().getPublicSchema());
 	}
@@ -440,13 +433,11 @@ public class TestTopologyDelete extends BaseTest {
 	}
 	
 	@Test
-	@Ignore
 	public void testDeleteEdgeIndexSchema() throws Exception {
 		testDeleteEdgeIndex("MySchema");
 	}
 	
 	@Test
-	@Ignore
 	public void testDeleteEdgeIndexNoSchema() throws Exception {
 		testDeleteEdgeIndex(this.sqlgGraph.getSqlDialect().getPublicSchema());
 	}

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/topology/TestTopologyDelete.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/topology/TestTopologyDelete.java
@@ -76,6 +76,13 @@ import org.umlg.sqlg.test.topology.TestTopologyChangeListener.TopologyListenerTe
 @RunWith(Parameterized.class)
 public class TestTopologyDelete extends BaseTest {
 	
+	@Parameter(0)
+	public String schema;
+	@Parameter(1)
+	public boolean preserve;
+	@Parameter(2)
+	public boolean rollback;
+	
 	@Parameters(name = "{index}: schema:{0}, preserve:{1}, rollback:{2}")
     public static Collection<Object[]> data() {
     	List<Object[]> l=new ArrayList<>();
@@ -93,9 +100,7 @@ public class TestTopologyDelete extends BaseTest {
         return l;
     }
     
-	public TestTopologyDelete() {
 
-	}
 	
 	@SuppressWarnings("Duplicates")
     @BeforeClass
@@ -112,13 +117,7 @@ public class TestTopologyDelete extends BaseTest {
             throw new IllegalStateException(e);
         }
     }
-	
-	@Parameter(0)
-	public String schema;
-	@Parameter(1)
-	public boolean preserve;
-	@Parameter(2)
-	public boolean rollback;
+
 	
 	@Before
 	public void buildLoops(){
@@ -292,12 +291,12 @@ public class TestTopologyDelete extends BaseTest {
 		assertEquals(0L,g.topology().V().hasLabel(SQLG_SCHEMA+"."+SQLG_SCHEMA_SCHEMA).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,schema)
 			.out(SQLG_SCHEMA_SCHEMA_VERTEX_EDGE).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,"A")
 			.out(SQLG_SCHEMA_OUT_EDGES_EDGE).has(SQLG_SCHEMA_EDGE_LABEL_NAME,"E")
-			.out(SQLG_SCHEMA_EDGE_PROPERTIES_EDGE).has(Topology.SQLG_SCHEMA_PROPERTY_NAME,"p1").count().next().longValue());
+			.out(SQLG_SCHEMA_EDGE_PROPERTIES_EDGE).has(SQLG_SCHEMA_PROPERTY_NAME,"p1").count().next().longValue());
 			
 		assertEquals(0L,g.topology().V().hasLabel(SQLG_SCHEMA+"."+SQLG_SCHEMA_SCHEMA).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,schema)
 				.out(SQLG_SCHEMA_SCHEMA_VERTEX_EDGE).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,"A")
 				.out(SQLG_SCHEMA_OUT_EDGES_EDGE).has(SQLG_SCHEMA_EDGE_LABEL_NAME,"E")
-				.out(SQLG_SCHEMA_EDGE_PROPERTIES_EDGE).has(Topology.SQLG_SCHEMA_PROPERTY_NAME,"p2").count().next().longValue());
+				.out(SQLG_SCHEMA_EDGE_PROPERTIES_EDGE).has(SQLG_SCHEMA_PROPERTY_NAME,"p2").count().next().longValue());
 			
 		assertFalse(columnExistsInSQL(schema, EDGE_PREFIX+"E", "p1"));
 		assertTrue(columnExistsInSQL(schema, EDGE_PREFIX+"E", "p2"));

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/topology/TestTopologyDelete.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/topology/TestTopologyDelete.java
@@ -1,0 +1,279 @@
+package org.umlg.sqlg.test.topology;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.umlg.sqlg.structure.SchemaManager.VERTEX_PREFIX;
+import static org.umlg.sqlg.structure.Topology.SQLG_SCHEMA;
+import static org.umlg.sqlg.structure.Topology.SQLG_SCHEMA_EDGE_LABEL_NAME;
+import static org.umlg.sqlg.structure.Topology.SQLG_SCHEMA_EDGE_PROPERTIES_EDGE;
+import static org.umlg.sqlg.structure.Topology.SQLG_SCHEMA_OUT_EDGES_EDGE;
+import static org.umlg.sqlg.structure.Topology.SQLG_SCHEMA_SCHEMA;
+import static org.umlg.sqlg.structure.Topology.SQLG_SCHEMA_SCHEMA_VERTEX_EDGE;
+import static org.umlg.sqlg.structure.Topology.SQLG_SCHEMA_VERTEX_LABEL_NAME;
+import static org.umlg.sqlg.structure.Topology.SQLG_SCHEMA_VERTEX_PROPERTIES_EDGE;
+
+import java.beans.PropertyVetoException;
+import java.io.IOException;
+import java.net.URL;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Optional;
+
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.umlg.sqlg.structure.EdgeLabel;
+import org.umlg.sqlg.structure.PropertyColumn;
+import org.umlg.sqlg.structure.SchemaManager;
+import org.umlg.sqlg.structure.SqlgGraph;
+import org.umlg.sqlg.structure.Topology;
+import org.umlg.sqlg.structure.TopologyChangeAction;
+import org.umlg.sqlg.structure.VertexLabel;
+import org.umlg.sqlg.test.BaseTest;
+import org.umlg.sqlg.test.topology.TestTopologyChangeListener.TopologyListenerTest;
+
+/**
+ * Test the deletion of topology items
+ * @author jpmoresmau
+ *
+ */
+public class TestTopologyDelete extends BaseTest {
+
+	public TestTopologyDelete() {
+
+	}
+	
+	@SuppressWarnings("Duplicates")
+    @BeforeClass
+    public static void beforeClass() throws ClassNotFoundException, IOException, PropertyVetoException {
+        URL sqlProperties = Thread.currentThread().getContextClassLoader().getResource("sqlg.properties");
+        try {
+            configuration = new PropertiesConfiguration(sqlProperties);
+            Assume.assumeTrue(configuration.getString("jdbc.url").contains("postgresql"));
+            configuration.addProperty("distributed", true);
+            if (!configuration.containsKey("jdbc.url"))
+                throw new IllegalArgumentException(String.format("SqlGraph configuration requires that the %s be set", "jdbc.url"));
+
+        } catch (ConfigurationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+	
+	
+	private boolean columnExistsInSQL(String schema,String table,String column) throws SQLException {
+		try (ResultSet rs=this.sqlgGraph.tx().getConnection().getMetaData().getColumns(null, schema, table, column)){
+			return rs.next();
+		}
+		
+	}
+	
+	private void checkPropertyExistenceBeforeDeletion(String schema) throws Exception {
+		Optional<VertexLabel> olbl=this.sqlgGraph.getTopology().getVertexLabel(schema, "A");
+		assertNotNull(olbl);
+		assertTrue(olbl.isPresent());
+		assertTrue(olbl.get().getProperty("p1").isPresent());
+		assertTrue(olbl.get().getProperty("p2").isPresent());
+		
+		assertEquals(1L,this.sqlgGraph.topology().V().hasLabel(SQLG_SCHEMA+"."+SQLG_SCHEMA_SCHEMA).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,schema)
+			.out(SQLG_SCHEMA_SCHEMA_VERTEX_EDGE).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,"A")
+			.out(SQLG_SCHEMA_VERTEX_PROPERTIES_EDGE).has(Topology.SQLG_SCHEMA_PROPERTY_NAME,"p1").count().next().longValue());
+			
+		assertEquals(1L,this.sqlgGraph.topology().V().hasLabel(SQLG_SCHEMA+"."+SQLG_SCHEMA_SCHEMA).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,schema)
+				.out(SQLG_SCHEMA_SCHEMA_VERTEX_EDGE).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,"A")
+				.out(SQLG_SCHEMA_VERTEX_PROPERTIES_EDGE).has(Topology.SQLG_SCHEMA_PROPERTY_NAME,"p2").count().next().longValue());
+			
+		assertTrue(columnExistsInSQL(schema, VERTEX_PREFIX+"A", "p1"));
+		assertTrue(columnExistsInSQL(schema, VERTEX_PREFIX+"A", "p2"));
+		
+	}
+	
+	private void checkPropertyExistenceAfterDeletion(SqlgGraph g,String schema) throws Exception {
+		Optional<VertexLabel> olbl=g.getTopology().getVertexLabel(schema, "A");
+		assertNotNull(olbl);
+		assertTrue(olbl.isPresent());
+		assertFalse(olbl.get().getProperty("p1").isPresent());
+		assertFalse(olbl.get().getProperty("p2").isPresent());
+		
+		assertEquals(0L,g.topology().V().hasLabel(SQLG_SCHEMA+"."+SQLG_SCHEMA_SCHEMA).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,schema)
+			.out(SQLG_SCHEMA_SCHEMA_VERTEX_EDGE).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,"A")
+			.out(SQLG_SCHEMA_VERTEX_PROPERTIES_EDGE).has(Topology.SQLG_SCHEMA_PROPERTY_NAME,"p1").count().next().longValue());
+			
+		assertEquals(0L,g.topology().V().hasLabel(SQLG_SCHEMA+"."+SQLG_SCHEMA_SCHEMA).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,schema)
+				.out(SQLG_SCHEMA_SCHEMA_VERTEX_EDGE).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,"A")
+				.out(SQLG_SCHEMA_VERTEX_PROPERTIES_EDGE).has(Topology.SQLG_SCHEMA_PROPERTY_NAME,"p2").count().next().longValue());
+			
+		assertFalse(columnExistsInSQL(schema, VERTEX_PREFIX+"A", "p1"));
+		assertTrue(columnExistsInSQL(schema, VERTEX_PREFIX+"A", "p2"));
+		
+	}
+	
+	
+	@Test
+	public void testDeleteVertexPropertySchema() throws Exception {
+		testDeleteVertexProperty("MySchema");
+	}
+	
+	@Test
+	public void testDeleteVertexPropertyNoSchema() throws Exception {
+		testDeleteVertexProperty(this.sqlgGraph.getSqlDialect().getPublicSchema());
+	}
+	
+	private void testDeleteVertexProperty(String schema) throws Exception {
+		try (SqlgGraph sqlgGraph1 = SqlgGraph.open(configuration)) {
+			String fullLabel=schema.equals(this.sqlgGraph.getSqlDialect().getPublicSchema())?"A":schema+".A";
+			Vertex a1 = this.sqlgGraph.addVertex(T.label, fullLabel, "name", "A","p1","val1","p2","val2");
+			
+			assertTrue(a1.property("p1").isPresent());
+			assertTrue(a1.property("p2").isPresent());
+			checkPropertyExistenceBeforeDeletion(schema);
+			this.sqlgGraph.tx().commit();
+			
+			Object aid=a1.id();
+			
+			checkPropertyExistenceBeforeDeletion(schema);
+			a1=this.sqlgGraph.traversal().V(aid).next();
+			assertTrue(a1.property("p1").isPresent());
+			assertTrue(a1.property("p2").isPresent());
+			
+			TopologyListenerTest tlt=new TopologyListenerTest();
+			this.sqlgGraph.getTopology().registerListener(tlt);
+			
+			VertexLabel lbl=this.sqlgGraph.getTopology().getVertexLabel(schema, "A").get();
+			PropertyColumn p1=lbl.getProperty("p1").get();
+			p1.remove(false);
+			PropertyColumn p2=lbl.getProperty("p2").get();
+			p2.remove(true);
+			
+			assertTrue(tlt.receivedEvent(p1, TopologyChangeAction.DELETE));
+			assertTrue(tlt.receivedEvent(p2, TopologyChangeAction.DELETE));
+			
+			checkPropertyExistenceAfterDeletion(this.sqlgGraph,schema);
+			/* doesn't work because the topology allTableCache is only updated after commit
+			a1=this.sqlgGraph.traversal().V(aid).next();
+			assertFalse(a1.property("p1").isPresent());
+			assertFalse(a1.property("p2").isPresent());
+			*/
+			this.sqlgGraph.tx().commit();
+			checkPropertyExistenceAfterDeletion(this.sqlgGraph,schema);
+			
+			a1=this.sqlgGraph.traversal().V(aid).next();
+			assertFalse(a1.property("p1").isPresent());
+			assertFalse(a1.property("p2").isPresent());
+		
+			Thread.sleep(1_000);
+			checkPropertyExistenceAfterDeletion(sqlgGraph1,schema);
+		}
+	}
+	
+	private void checkEdgePropertyExistenceBeforeDeletion(String schema) throws Exception {
+		Optional<EdgeLabel> olbl=this.sqlgGraph.getTopology().getEdgeLabel(schema, "E");
+		assertNotNull(olbl);
+		assertTrue(olbl.isPresent());
+		assertTrue(olbl.get().getProperty("p1").isPresent());
+		assertTrue(olbl.get().getProperty("p2").isPresent());
+		
+		assertEquals(1L,this.sqlgGraph.topology().V().hasLabel(SQLG_SCHEMA+"."+SQLG_SCHEMA_SCHEMA).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,schema)
+			.out(SQLG_SCHEMA_SCHEMA_VERTEX_EDGE).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,"A")
+			.out(SQLG_SCHEMA_OUT_EDGES_EDGE).has(SQLG_SCHEMA_EDGE_LABEL_NAME,"E")
+			.out(SQLG_SCHEMA_EDGE_PROPERTIES_EDGE).has(Topology.SQLG_SCHEMA_PROPERTY_NAME,"p1").count().next().longValue());
+			
+		assertEquals(1L,this.sqlgGraph.topology().V().hasLabel(SQLG_SCHEMA+"."+SQLG_SCHEMA_SCHEMA).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,schema)
+				.out(SQLG_SCHEMA_SCHEMA_VERTEX_EDGE).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,"A")
+				.out(SQLG_SCHEMA_OUT_EDGES_EDGE).has(SQLG_SCHEMA_EDGE_LABEL_NAME,"E")
+				.out(SQLG_SCHEMA_EDGE_PROPERTIES_EDGE).has(Topology.SQLG_SCHEMA_PROPERTY_NAME,"p2").count().next().longValue());
+			
+		assertTrue(columnExistsInSQL(schema, SchemaManager.EDGE_PREFIX+"E", "p1"));
+		assertTrue(columnExistsInSQL(schema, SchemaManager.EDGE_PREFIX+"E", "p2"));
+		
+	}
+	
+	private void checkEdgePropertyExistenceAfterDeletion(SqlgGraph g,String schema) throws Exception {
+		Optional<EdgeLabel> olbl=g.getTopology().getEdgeLabel(schema, "E");
+		assertNotNull(olbl);
+		assertTrue(olbl.isPresent());
+		assertFalse(olbl.get().getProperty("p1").isPresent());
+		assertFalse(olbl.get().getProperty("p2").isPresent());
+		
+		assertEquals(0L,g.topology().V().hasLabel(SQLG_SCHEMA+"."+SQLG_SCHEMA_SCHEMA).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,schema)
+			.out(SQLG_SCHEMA_SCHEMA_VERTEX_EDGE).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,"A")
+			.out(SQLG_SCHEMA_OUT_EDGES_EDGE).has(SQLG_SCHEMA_EDGE_LABEL_NAME,"E")
+			.out(SQLG_SCHEMA_EDGE_PROPERTIES_EDGE).has(Topology.SQLG_SCHEMA_PROPERTY_NAME,"p1").count().next().longValue());
+			
+		assertEquals(0L,g.topology().V().hasLabel(SQLG_SCHEMA+"."+SQLG_SCHEMA_SCHEMA).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,schema)
+				.out(SQLG_SCHEMA_SCHEMA_VERTEX_EDGE).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,"A")
+				.out(SQLG_SCHEMA_OUT_EDGES_EDGE).has(SQLG_SCHEMA_EDGE_LABEL_NAME,"E")
+				.out(SQLG_SCHEMA_EDGE_PROPERTIES_EDGE).has(Topology.SQLG_SCHEMA_PROPERTY_NAME,"p2").count().next().longValue());
+			
+		assertFalse(columnExistsInSQL(schema, SchemaManager.EDGE_PREFIX+"E", "p1"));
+		assertTrue(columnExistsInSQL(schema, SchemaManager.EDGE_PREFIX+"E", "p2"));
+		
+	}
+	
+	
+
+	@Test
+	public void testDeleteEdgePropertySchema() throws Exception {
+		testDeleteEdgeProperty("MySchema");
+	}
+	
+	@Test
+	public void testDeleteEdgePropertyNoSchema() throws Exception {
+		testDeleteEdgeProperty(this.sqlgGraph.getSqlDialect().getPublicSchema());
+	}
+	
+	private void testDeleteEdgeProperty(String schema) throws Exception {
+		try (SqlgGraph sqlgGraph1 = SqlgGraph.open(configuration)) {
+			String fullLabelA=schema.equals(this.sqlgGraph.getSqlDialect().getPublicSchema())?"A":schema+".A";
+			String fullLabelB=schema.equals(this.sqlgGraph.getSqlDialect().getPublicSchema())?"B":schema+".B";
+			Vertex a1 = this.sqlgGraph.addVertex(T.label, fullLabelA, "name", "A");
+			Vertex b1 = this.sqlgGraph.addVertex(T.label, fullLabelB, "name", "B");
+			Edge e1=a1.addEdge("E", b1, "p1","val1","p2","val2");
+			
+			assertTrue(e1.property("p1").isPresent());
+			assertTrue(e1.property("p2").isPresent());
+			checkEdgePropertyExistenceBeforeDeletion(schema);
+			sqlgGraph.tx().commit();
+			Object eid=e1.id();
+			checkEdgePropertyExistenceBeforeDeletion(schema);
+			e1=this.sqlgGraph.traversal().E(eid).next();
+			assertTrue(e1.property("p1").isPresent());
+			assertTrue(e1.property("p2").isPresent());
+			
+			TopologyListenerTest tlt=new TopologyListenerTest();
+			this.sqlgGraph.getTopology().registerListener(tlt);
+			
+			EdgeLabel lbl=this.sqlgGraph.getTopology().getEdgeLabel(schema, "E").get();
+			PropertyColumn p1=lbl.getProperty("p1").get();
+			p1.remove(false);
+			PropertyColumn p2=lbl.getProperty("p2").get();
+			p2.remove(true);
+			
+			assertTrue(tlt.receivedEvent(p1, TopologyChangeAction.DELETE));
+			assertTrue(tlt.receivedEvent(p2, TopologyChangeAction.DELETE));
+			
+			checkEdgePropertyExistenceAfterDeletion(this.sqlgGraph,schema);
+			/* doesn't work because the topology allTableCache is only updated after commit
+			a1=this.sqlgGraph.traversal().V(aid).next();
+			assertFalse(a1.property("p1").isPresent());
+			assertFalse(a1.property("p2").isPresent());
+			*/
+			this.sqlgGraph.tx().commit();
+			checkEdgePropertyExistenceAfterDeletion(this.sqlgGraph,schema);
+			
+			
+			e1=this.sqlgGraph.traversal().E(eid).next();
+			assertFalse(e1.property("p1").isPresent());
+			assertFalse(e1.property("p2").isPresent());
+			
+			Thread.sleep(1_000);
+			checkEdgePropertyExistenceAfterDeletion(sqlgGraph1,schema);
+		}
+	}
+}

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/topology/TestTopologyDelete.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/topology/TestTopologyDelete.java
@@ -26,19 +26,24 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.Set;
 
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Assume;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.umlg.sqlg.structure.EdgeLabel;
+import org.umlg.sqlg.structure.EdgeRole;
 import org.umlg.sqlg.structure.Index;
 import org.umlg.sqlg.structure.IndexType;
 import org.umlg.sqlg.structure.PropertyColumn;
+import org.umlg.sqlg.structure.SchemaManager;
 import org.umlg.sqlg.structure.SqlgGraph;
 import org.umlg.sqlg.structure.Topology;
 import org.umlg.sqlg.structure.TopologyChangeAction;
@@ -143,18 +148,20 @@ public class TestTopologyDelete extends BaseTest {
 	
 	
 	@Test
+	@Ignore
 	public void testDeleteVertexPropertySchema() throws Exception {
 		testDeleteVertexProperty("MySchema");
 	}
 	
 	@Test
+	@Ignore
 	public void testDeleteVertexPropertyNoSchema() throws Exception {
 		testDeleteVertexProperty(this.sqlgGraph.getSqlDialect().getPublicSchema());
 	}
 	
 	private void testDeleteVertexProperty(String schema) throws Exception {
 		try (SqlgGraph sqlgGraph1 = SqlgGraph.open(configuration)) {
-			String fullLabel=schema.equals(this.sqlgGraph.getSqlDialect().getPublicSchema())?"A":schema+".A";
+			String fullLabel=getLabel(schema,"A");
 			Vertex a1 = this.sqlgGraph.addVertex(T.label, fullLabel, "name", "A","p1","val1","p2","val2");
 			
 			assertTrue(a1.property("p1").isPresent());
@@ -246,19 +253,21 @@ public class TestTopologyDelete extends BaseTest {
 	
 
 	@Test
+	@Ignore
 	public void testDeleteEdgePropertySchema() throws Exception {
 		testDeleteEdgeProperty("MySchema");
 	}
 	
 	@Test
+	@Ignore
 	public void testDeleteEdgePropertyNoSchema() throws Exception {
 		testDeleteEdgeProperty(this.sqlgGraph.getSqlDialect().getPublicSchema());
 	}
 	
 	private void testDeleteEdgeProperty(String schema) throws Exception {
 		try (SqlgGraph sqlgGraph1 = SqlgGraph.open(configuration)) {
-			String fullLabelA=schema.equals(this.sqlgGraph.getSqlDialect().getPublicSchema())?"A":schema+".A";
-			String fullLabelB=schema.equals(this.sqlgGraph.getSqlDialect().getPublicSchema())?"B":schema+".B";
+			String fullLabelA=getLabel(schema,"A");
+			String fullLabelB=getLabel(schema,"B");
 			Vertex a1 = this.sqlgGraph.addVertex(T.label, fullLabelA, "name", "A");
 			Vertex b1 = this.sqlgGraph.addVertex(T.label, fullLabelB, "name", "B");
 			Edge e1=a1.addEdge("E", b1, "p1","val1","p2","val2");
@@ -345,18 +354,20 @@ public class TestTopologyDelete extends BaseTest {
 	}
 	
 	@Test
+	@Ignore
 	public void testDeleteVertexIndexSchema() throws Exception {
 		testDeleteVertexIndex("MySchema");
 	}
 	
 	@Test
+	@Ignore
 	public void testDeleteVertexIndexNoSchema() throws Exception {
 		testDeleteVertexIndex(this.sqlgGraph.getSqlDialect().getPublicSchema());
 	}
 	
 	private void testDeleteVertexIndex(String schema) throws Exception {
 		try (SqlgGraph sqlgGraph1 = SqlgGraph.open(configuration)) {
-			String fullLabel=schema.equals(this.sqlgGraph.getSqlDialect().getPublicSchema())?"A":schema+".A";
+			String fullLabel=getLabel(schema,"A");
 			this.sqlgGraph.addVertex(T.label, fullLabel, "name", "A","p1","val1","p2","val2");
 			VertexLabel lbl=this.sqlgGraph.getTopology().getVertexLabel(schema, "A").get();
 			
@@ -433,19 +444,21 @@ public class TestTopologyDelete extends BaseTest {
 	}
 	
 	@Test
+	@Ignore
 	public void testDeleteEdgeIndexSchema() throws Exception {
 		testDeleteEdgeIndex("MySchema");
 	}
 	
 	@Test
+	@Ignore
 	public void testDeleteEdgeIndexNoSchema() throws Exception {
 		testDeleteEdgeIndex(this.sqlgGraph.getSqlDialect().getPublicSchema());
 	}
 	
 	private void testDeleteEdgeIndex(String schema) throws Exception {
 		try (SqlgGraph sqlgGraph1 = SqlgGraph.open(configuration)) {
-			String fullLabelA=schema.equals(this.sqlgGraph.getSqlDialect().getPublicSchema())?"A":schema+".A";
-			String fullLabelB=schema.equals(this.sqlgGraph.getSqlDialect().getPublicSchema())?"B":schema+".B";
+			String fullLabelA=getLabel(schema,"A");
+			String fullLabelB=getLabel(schema,"B");
 			Vertex a1 = this.sqlgGraph.addVertex(T.label, fullLabelA, "name", "A");
 			Vertex b1 = this.sqlgGraph.addVertex(T.label, fullLabelB, "name", "B");
 			a1.addEdge("E", b1, "p1","val1","p2","val2");
@@ -479,24 +492,24 @@ public class TestTopologyDelete extends BaseTest {
 		}
 	}
 	
-	private void checkEdgeExistenceBeforeDeletion(String schema) throws Exception {
-		Optional<EdgeLabel> olbl=this.sqlgGraph.getTopology().getEdgeLabel(schema, "E1");
+	private void checkEdgeExistenceBeforeDeletion(SqlgGraph g,String schema) throws Exception {
+		Optional<EdgeLabel> olbl=g.getTopology().getEdgeLabel(schema, "E1");
 		assertNotNull(olbl);
 		assertTrue(olbl.isPresent());
-		olbl=this.sqlgGraph.getTopology().getEdgeLabel(schema, "E2");
+		olbl=g.getTopology().getEdgeLabel(schema, "E2");
 		assertNotNull(olbl);
 		assertTrue(olbl.isPresent());
 		
-		VertexLabel a=this.sqlgGraph.getTopology().getVertexLabel(schema, "A").get();
+		VertexLabel a=g.getTopology().getVertexLabel(schema, "A").get();
 		assertTrue(a.getOutEdgeLabel("E1").isPresent());
 		assertTrue(a.getOutEdgeLabel("E2").isPresent());
 	
 		
-		assertEquals(1L,this.sqlgGraph.topology().V().hasLabel(SQLG_SCHEMA+"."+SQLG_SCHEMA_SCHEMA).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,schema)
+		assertEquals(1L,g.topology().V().hasLabel(SQLG_SCHEMA+"."+SQLG_SCHEMA_SCHEMA).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,schema)
 			.out(SQLG_SCHEMA_SCHEMA_VERTEX_EDGE).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,"A")
 			.out(SQLG_SCHEMA_OUT_EDGES_EDGE).has(SQLG_SCHEMA_EDGE_LABEL_NAME,"E1").count().next().longValue());
 			
-		assertEquals(1L,this.sqlgGraph.topology().V().hasLabel(SQLG_SCHEMA+"."+SQLG_SCHEMA_SCHEMA).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,schema)
+		assertEquals(1L,g.topology().V().hasLabel(SQLG_SCHEMA+"."+SQLG_SCHEMA_SCHEMA).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,schema)
 				.out(SQLG_SCHEMA_SCHEMA_VERTEX_EDGE).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,"A")
 				.out(SQLG_SCHEMA_OUT_EDGES_EDGE).has(SQLG_SCHEMA_EDGE_LABEL_NAME,"E2").count().next().longValue());
 			
@@ -531,19 +544,26 @@ public class TestTopologyDelete extends BaseTest {
 	}
 	
 	@Test
+	@Ignore
 	public void testDeleteEdgeSchema() throws Exception {
 		testDeleteEdge("MySchema");
 	}
 	
 	@Test
+	@Ignore
 	public void testDeleteEdgeNoSchema() throws Exception {
 		testDeleteEdge(this.sqlgGraph.getSqlDialect().getPublicSchema());
 	}
 	
+	private String getLabel(String schema, String type){
+		return schema.equals(this.sqlgGraph.getSqlDialect().getPublicSchema())?type:schema+"."+type;
+		
+	}
+	
 	private void testDeleteEdge(String schema) throws Exception {
 		try (SqlgGraph sqlgGraph1 = SqlgGraph.open(configuration)) {
-			String fullLabelA=schema.equals(this.sqlgGraph.getSqlDialect().getPublicSchema())?"A":schema+".A";
-			String fullLabelB=schema.equals(this.sqlgGraph.getSqlDialect().getPublicSchema())?"B":schema+".B";
+			String fullLabelA=getLabel(schema,"A");
+			String fullLabelB=getLabel(schema,"B");
 			Vertex a1 = this.sqlgGraph.addVertex(T.label, fullLabelA, "name", "A");
 			Vertex b1 = this.sqlgGraph.addVertex(T.label, fullLabelB, "name", "B1");
 			Vertex b2 = this.sqlgGraph.addVertex(T.label, fullLabelB, "name", "B2");
@@ -551,10 +571,12 @@ public class TestTopologyDelete extends BaseTest {
 			a1.addEdge("E2", b2);
 			
 						
-			checkEdgeExistenceBeforeDeletion(schema);
+			checkEdgeExistenceBeforeDeletion(this.sqlgGraph,schema);
 			this.sqlgGraph.tx().commit();
 			
-			checkEdgeExistenceBeforeDeletion(schema);
+			checkEdgeExistenceBeforeDeletion(this.sqlgGraph,schema);
+			Thread.sleep(1_000);
+			checkEdgeExistenceBeforeDeletion(this.sqlgGraph1,schema);
 			
 			TopologyListenerTest tlt=new TopologyListenerTest();
 			this.sqlgGraph.getTopology().registerListener(tlt);
@@ -575,6 +597,148 @@ public class TestTopologyDelete extends BaseTest {
 			
 			Thread.sleep(1_000);
 			checkEdgeExistenceAfterDeletion(sqlgGraph1,schema);
+		}
+	}
+	
+	private void checkEdgeRoleExistenceBeforeDeletion(String schemaOut,String schemaIn) throws Exception {
+		Optional<EdgeLabel> olbl=this.sqlgGraph.getTopology().getEdgeLabel(schemaOut, "E1");
+		assertNotNull(olbl);
+		assertTrue(olbl.isPresent());
+		
+		VertexLabel a=this.sqlgGraph.getTopology().getVertexLabel(schemaOut, "A").get();
+		VertexLabel b=this.sqlgGraph.getTopology().getVertexLabel(schemaOut, "B").get();
+		VertexLabel pa=this.sqlgGraph.getTopology().getVertexLabel(schemaIn, "A").get();
+		VertexLabel pb=this.sqlgGraph.getTopology().getVertexLabel(schemaIn, "B").get();
+		assertEquals(1,a.getOutEdgeLabels().size());
+		assertEquals(1,b.getOutEdgeLabels().size());
+		assertEquals(1,pb.getInEdgeLabels().size());
+		assertEquals(1,pa.getInEdgeLabels().size());
+		
+		Set<VertexLabel> inLbls=olbl.get().getInVertexLabels();
+		assertEquals(2,inLbls.size());
+		assertTrue(inLbls.contains(pa));
+		assertTrue(inLbls.contains(pb));
+		
+		Set<EdgeRole> inRoles=olbl.get().getInEdgeRoles();
+		assertEquals(2,inRoles.size());
+		
+		
+		Set<VertexLabel> outLbls=olbl.get().getOutVertexLabels();
+		assertEquals(2,outLbls.size());
+		assertTrue(outLbls.contains(a));
+		assertTrue(outLbls.contains(b));
+		
+		Set<EdgeRole> outRoles=olbl.get().getOutEdgeRoles();
+		assertEquals(2,outRoles.size());
+		
+		
+		assertTrue(tableExistsInSQL(schemaOut, EDGE_PREFIX+"E1"));
+		assertTrue(columnExistsInSQL(schemaOut, EDGE_PREFIX+"E1", schemaOut+".A"+SchemaManager.OUT_VERTEX_COLUMN_END));
+		assertTrue(columnExistsInSQL(schemaOut, EDGE_PREFIX+"E1", schemaOut+".B"+SchemaManager.OUT_VERTEX_COLUMN_END));
+		assertTrue(columnExistsInSQL(schemaOut, EDGE_PREFIX+"E1", schemaIn+".A"+SchemaManager.IN_VERTEX_COLUMN_END));
+		assertTrue(columnExistsInSQL(schemaOut, EDGE_PREFIX+"E1", schemaIn+".B"+SchemaManager.IN_VERTEX_COLUMN_END));
+	}
+	
+	private void checkEdgeRoleExistenceAfterRoleDeletion(SqlgGraph g,String schemaOut,String schemaIn) throws Exception {
+		Optional<EdgeLabel> olbl=g.getTopology().getEdgeLabel(schemaOut, "E1");
+		assertNotNull(olbl);
+		assertTrue(olbl.isPresent());
+		
+		VertexLabel a=g.getTopology().getVertexLabel(schemaOut, "A").get();
+		VertexLabel b=g.getTopology().getVertexLabel(schemaOut, "B").get();
+		VertexLabel pa=g.getTopology().getVertexLabel(schemaIn, "A").get();
+		VertexLabel pb=g.getTopology().getVertexLabel(schemaIn, "B").get();
+		assertEquals(1,a.getOutEdgeLabels().size());
+		assertEquals(0,b.getOutEdgeLabels().size());
+		assertEquals(1,pb.getInEdgeLabels().size());
+		assertEquals(0,pa.getInEdgeLabels().size());
+		
+		Set<VertexLabel> inLbls=olbl.get().getInVertexLabels();
+		assertEquals(1,inLbls.size());
+		assertFalse(inLbls.contains(pa));
+		assertTrue(inLbls.contains(pb));
+		
+		Set<EdgeRole> inRoles=olbl.get().getInEdgeRoles();
+		assertEquals(1,inRoles.size());
+		assertEquals("B",inRoles.iterator().next().getVertexLabel().getName());
+		
+		
+		Set<VertexLabel> outLbls=olbl.get().getOutVertexLabels();
+		assertEquals(1,outLbls.size());
+		assertTrue(outLbls.contains(a));
+		assertFalse(outLbls.contains(b));
+		
+		Set<EdgeRole> outRoles=olbl.get().getOutEdgeRoles();
+		assertEquals(1,outRoles.size());
+		assertEquals("A",outRoles.iterator().next().getVertexLabel().getName());
+		
+		assertTrue(tableExistsInSQL(schemaOut, EDGE_PREFIX+"E1"));
+		assertTrue(columnExistsInSQL(schemaOut, EDGE_PREFIX+"E1", schemaOut+".A"+SchemaManager.OUT_VERTEX_COLUMN_END));
+		assertFalse(columnExistsInSQL(schemaOut, EDGE_PREFIX+"E1", schemaOut+".B"+SchemaManager.OUT_VERTEX_COLUMN_END));
+		assertTrue(columnExistsInSQL(schemaOut, EDGE_PREFIX+"E1", schemaIn+".A"+SchemaManager.IN_VERTEX_COLUMN_END));
+		assertTrue(columnExistsInSQL(schemaOut, EDGE_PREFIX+"E1", schemaIn+".B"+SchemaManager.IN_VERTEX_COLUMN_END));
+	}
+	
+	@Test
+	public void testDeleteEdgeRoleSchemaPublic() throws Exception{
+		testDeleteEdgeRole("MySchema", sqlgGraph.getSqlDialect().getPublicSchema());
+	}
+	
+	@Test
+	public void testDeleteEdgeRolePublicSchema() throws Exception{
+		testDeleteEdgeRole(sqlgGraph.getSqlDialect().getPublicSchema(),"MySchema");
+	}
+	
+	private void testDeleteEdgeRole(String schemaOut,String schemaIn) throws Exception {
+		try (SqlgGraph sqlgGraph1 = SqlgGraph.open(configuration)) {
+			String Aout=getLabel(schemaOut,"A");
+			String Bout=getLabel(schemaOut,"B");
+			String Ain=getLabel(schemaIn,"A");
+			String Bin=getLabel(schemaIn,"B");
+			Vertex a1 = this.sqlgGraph.addVertex(T.label, Aout, "name", "A1");
+			Vertex a2 = this.sqlgGraph.addVertex(T.label, Ain, "name", "A2");
+			
+			Vertex b1 = this.sqlgGraph.addVertex(T.label, Bout, "name", "B1");
+			Vertex b2 = this.sqlgGraph.addVertex(T.label, Bin, "name", "B2");
+			a1.addEdge("E1", b2);
+			b1.addEdge("E1", a2);
+			
+			//checkEdgeRoleExistenceBeforeDeletion();
+			this.sqlgGraph.tx().commit();
+			
+			checkEdgeRoleExistenceBeforeDeletion(schemaOut,schemaIn);
+			
+			TopologyListenerTest tlt=new TopologyListenerTest();
+			this.sqlgGraph.getTopology().registerListener(tlt);
+			
+			
+			EdgeLabel lbl=this.sqlgGraph.getTopology().getEdgeLabel(schemaOut, "E1").get();
+			for (EdgeRole er:lbl.getOutEdgeRoles()){
+				if (er.getVertexLabel().getName().equals("B")){
+					er.remove(false);
+					assertTrue(tlt.receivedEvent(er, TopologyChangeAction.DELETE));
+					
+				}
+			}
+			for (EdgeRole er:lbl.getInEdgeRoles()){
+				if (er.getVertexLabel().getName().equals("A")){
+					er.remove(true);
+					assertTrue(tlt.receivedEvent(er, TopologyChangeAction.DELETE));
+					
+				}
+			}
+			this.sqlgGraph.tx().commit();
+			checkEdgeRoleExistenceAfterRoleDeletion(this.sqlgGraph,schemaOut,schemaIn);
+			Thread.sleep(1_000);
+			checkEdgeRoleExistenceAfterRoleDeletion(sqlgGraph1,schemaOut,schemaIn);
+			
+			assertFalse(b1.edges(Direction.OUT, "E1").hasNext());
+			assertTrue(a1.edges(Direction.OUT, "E1").hasNext());
+			
+			lbl.getOutEdgeRoles().iterator().next().remove(false);
+			assertFalse(this.sqlgGraph.getTopology().getEdgeLabel(schemaOut, "E1").isPresent());
+			this.sqlgGraph.tx().commit();
+			assertFalse(this.sqlgGraph.getTopology().getEdgeLabel(schemaOut, "E1").isPresent());			
 		}
 	}
 }

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/topology/TestTopologyDelete.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/topology/TestTopologyDelete.java
@@ -148,13 +148,13 @@ public class TestTopologyDelete extends BaseTest {
 	
 	
 	@Test
-	@Ignore
+	
 	public void testDeleteVertexPropertySchema() throws Exception {
 		testDeleteVertexProperty("MySchema");
 	}
 	
 	@Test
-	@Ignore
+	
 	public void testDeleteVertexPropertyNoSchema() throws Exception {
 		testDeleteVertexProperty(this.sqlgGraph.getSqlDialect().getPublicSchema());
 	}
@@ -253,13 +253,11 @@ public class TestTopologyDelete extends BaseTest {
 	
 
 	@Test
-	@Ignore
 	public void testDeleteEdgePropertySchema() throws Exception {
 		testDeleteEdgeProperty("MySchema");
 	}
 	
 	@Test
-	@Ignore
 	public void testDeleteEdgePropertyNoSchema() throws Exception {
 		testDeleteEdgeProperty(this.sqlgGraph.getSqlDialect().getPublicSchema());
 	}
@@ -354,13 +352,13 @@ public class TestTopologyDelete extends BaseTest {
 	}
 	
 	@Test
-	@Ignore
+	
 	public void testDeleteVertexIndexSchema() throws Exception {
 		testDeleteVertexIndex("MySchema");
 	}
 	
 	@Test
-	@Ignore
+	
 	public void testDeleteVertexIndexNoSchema() throws Exception {
 		testDeleteVertexIndex(this.sqlgGraph.getSqlDialect().getPublicSchema());
 	}
@@ -444,13 +442,13 @@ public class TestTopologyDelete extends BaseTest {
 	}
 	
 	@Test
-	@Ignore
+	
 	public void testDeleteEdgeIndexSchema() throws Exception {
 		testDeleteEdgeIndex("MySchema");
 	}
 	
 	@Test
-	@Ignore
+	
 	public void testDeleteEdgeIndexNoSchema() throws Exception {
 		testDeleteEdgeIndex(this.sqlgGraph.getSqlDialect().getPublicSchema());
 	}
@@ -519,22 +517,22 @@ public class TestTopologyDelete extends BaseTest {
 	}
 	
 	private void checkEdgeExistenceAfterDeletion(SqlgGraph g,String schema) throws Exception {
-		Optional<EdgeLabel> olbl=this.sqlgGraph.getTopology().getEdgeLabel(schema, "E1");
+		Optional<EdgeLabel> olbl=g.getTopology().getEdgeLabel(schema, "E1");
 		assertNotNull(olbl);
 		assertFalse(olbl.isPresent());
-		olbl=this.sqlgGraph.getTopology().getEdgeLabel(schema, "E2");
+		olbl=g.getTopology().getEdgeLabel(schema, "E2");
 		assertNotNull(olbl);
 		assertFalse(olbl.isPresent());
 		
-		VertexLabel a=this.sqlgGraph.getTopology().getVertexLabel(schema, "A").get();
+		VertexLabel a=g.getTopology().getVertexLabel(schema, "A").get();
 		assertFalse(a.getOutEdgeLabel("E1").isPresent());
 		assertFalse(a.getOutEdgeLabel("E2").isPresent());
 		
-		assertEquals(0L,this.sqlgGraph.topology().V().hasLabel(SQLG_SCHEMA+"."+SQLG_SCHEMA_SCHEMA).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,schema)
+		assertEquals(0L,g.topology().V().hasLabel(SQLG_SCHEMA+"."+SQLG_SCHEMA_SCHEMA).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,schema)
 				.out(SQLG_SCHEMA_SCHEMA_VERTEX_EDGE).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,"A")
 				.out(SQLG_SCHEMA_OUT_EDGES_EDGE).has(SQLG_SCHEMA_EDGE_LABEL_NAME,"E1").count().next().longValue());
 				
-		assertEquals(0L,this.sqlgGraph.topology().V().hasLabel(SQLG_SCHEMA+"."+SQLG_SCHEMA_SCHEMA).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,schema)
+		assertEquals(0L,g.topology().V().hasLabel(SQLG_SCHEMA+"."+SQLG_SCHEMA_SCHEMA).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,schema)
 				.out(SQLG_SCHEMA_SCHEMA_VERTEX_EDGE).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,"A")
 				.out(SQLG_SCHEMA_OUT_EDGES_EDGE).has(SQLG_SCHEMA_EDGE_LABEL_NAME,"E2").count().next().longValue());
 			
@@ -544,13 +542,13 @@ public class TestTopologyDelete extends BaseTest {
 	}
 	
 	@Test
-	@Ignore
+	
 	public void testDeleteEdgeSchema() throws Exception {
 		testDeleteEdge("MySchema");
 	}
 	
 	@Test
-	@Ignore
+	
 	public void testDeleteEdgeNoSchema() throws Exception {
 		testDeleteEdge(this.sqlgGraph.getSqlDialect().getPublicSchema());
 	}
@@ -680,11 +678,13 @@ public class TestTopologyDelete extends BaseTest {
 	}
 	
 	@Test
+	
 	public void testDeleteEdgeRoleSchemaPublic() throws Exception{
 		testDeleteEdgeRole("MySchema", sqlgGraph.getSqlDialect().getPublicSchema());
 	}
 	
 	@Test
+	
 	public void testDeleteEdgeRolePublicSchema() throws Exception{
 		testDeleteEdgeRole(sqlgGraph.getSqlDialect().getPublicSchema(),"MySchema");
 	}
@@ -739,6 +739,156 @@ public class TestTopologyDelete extends BaseTest {
 			assertFalse(this.sqlgGraph.getTopology().getEdgeLabel(schemaOut, "E1").isPresent());
 			this.sqlgGraph.tx().commit();
 			assertFalse(this.sqlgGraph.getTopology().getEdgeLabel(schemaOut, "E1").isPresent());			
+		}
+	}
+	
+	private void checkVertexLabelBeforeDeletion(SqlgGraph g,String schema) throws Exception {
+		Optional<VertexLabel> olbl=g.getTopology().getVertexLabel(schema, "A");
+		assertNotNull(olbl);
+		assertTrue(olbl.isPresent());
+		
+		olbl=g.getTopology().getVertexLabel(schema, "B");
+		assertNotNull(olbl);
+		assertTrue(olbl.isPresent());
+		
+		olbl=g.getTopology().getVertexLabel(schema, "C");
+		assertNotNull(olbl);
+		assertTrue(olbl.isPresent());
+		
+		olbl=g.getTopology().getVertexLabel(schema, "D");
+		assertNotNull(olbl);
+		assertTrue(olbl.isPresent());
+		
+		assertEquals(1L,g.topology().V().hasLabel(SQLG_SCHEMA+"."+SQLG_SCHEMA_SCHEMA).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,schema)
+				.out(SQLG_SCHEMA_SCHEMA_VERTEX_EDGE).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,"A").count().next().longValue());
+	
+		assertEquals(1L,g.topology().V().hasLabel(SQLG_SCHEMA+"."+SQLG_SCHEMA_SCHEMA).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,schema)
+				.out(SQLG_SCHEMA_SCHEMA_VERTEX_EDGE).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,"B").count().next().longValue());
+	
+		assertEquals(1L,g.topology().V().hasLabel(SQLG_SCHEMA+"."+SQLG_SCHEMA_SCHEMA).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,schema)
+				.out(SQLG_SCHEMA_SCHEMA_VERTEX_EDGE).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,"C").count().next().longValue());
+	
+		assertEquals(1L,g.topology().V().hasLabel(SQLG_SCHEMA+"."+SQLG_SCHEMA_SCHEMA).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,schema)
+				.out(SQLG_SCHEMA_SCHEMA_VERTEX_EDGE).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,"D").count().next().longValue());
+	
+		
+		assertTrue(tableExistsInSQL(schema, VERTEX_PREFIX+"A"));
+		assertTrue(tableExistsInSQL(schema, VERTEX_PREFIX+"B"));
+		assertTrue(tableExistsInSQL(schema, VERTEX_PREFIX+"C"));
+		assertTrue(tableExistsInSQL(schema, VERTEX_PREFIX+"D"));
+		
+		
+		Optional<EdgeLabel> oelbl=g.getTopology().getEdgeLabel(schema, "E");
+		assertNotNull(oelbl);
+		assertTrue(oelbl.isPresent());
+		EdgeLabel elbl=oelbl.get();
+		assertEquals(3,elbl.getInVertexLabels().size());
+		assertEquals(3,elbl.getOutVertexLabels().size());
+		
+	}
+	
+	private void checkVertexLabelAfterDeletion(SqlgGraph g,String schema) throws Exception {
+		Optional<VertexLabel> olbl=g.getTopology().getVertexLabel(schema, "A");
+		assertNotNull(olbl);
+		assertTrue(olbl.isPresent());
+		
+		olbl=g.getTopology().getVertexLabel(schema, "B");
+		assertNotNull(olbl);
+		assertTrue(olbl.isPresent());
+		
+		olbl=g.getTopology().getVertexLabel(schema, "C");
+		assertNotNull(olbl);
+		assertFalse(olbl.isPresent());
+		
+		olbl=g.getTopology().getVertexLabel(schema, "D");
+		assertNotNull(olbl);
+		assertFalse(olbl.isPresent());
+		
+		assertEquals(1L,g.topology().V().hasLabel(SQLG_SCHEMA+"."+SQLG_SCHEMA_SCHEMA).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,schema)
+				.out(SQLG_SCHEMA_SCHEMA_VERTEX_EDGE).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,"A").count().next().longValue());
+	
+		assertEquals(1L,g.topology().V().hasLabel(SQLG_SCHEMA+"."+SQLG_SCHEMA_SCHEMA).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,schema)
+				.out(SQLG_SCHEMA_SCHEMA_VERTEX_EDGE).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,"B").count().next().longValue());
+	
+		assertEquals(0L,g.topology().V().hasLabel(SQLG_SCHEMA+"."+SQLG_SCHEMA_SCHEMA).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,schema)
+				.out(SQLG_SCHEMA_SCHEMA_VERTEX_EDGE).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,"C").count().next().longValue());
+	
+		assertEquals(0L,g.topology().V().hasLabel(SQLG_SCHEMA+"."+SQLG_SCHEMA_SCHEMA).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,schema)
+				.out(SQLG_SCHEMA_SCHEMA_VERTEX_EDGE).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,"D").count().next().longValue());
+	
+		
+		assertTrue(tableExistsInSQL(schema, VERTEX_PREFIX+"A"));
+		assertTrue(tableExistsInSQL(schema, VERTEX_PREFIX+"B"));
+		assertFalse(tableExistsInSQL(schema, VERTEX_PREFIX+"C"));
+		assertTrue(tableExistsInSQL(schema, VERTEX_PREFIX+"D"));
+		
+		
+		Optional<EdgeLabel> oelbl=g.getTopology().getEdgeLabel(schema, "E");
+		assertNotNull(oelbl);
+		assertTrue(oelbl.isPresent());
+		EdgeLabel elbl=oelbl.get();
+		assertEquals(1,elbl.getInVertexLabels().size());
+		assertEquals(2,elbl.getOutVertexLabels().size());
+	}
+	
+	@Test
+	public void testDeleteVertexLabelSchema() throws Exception {
+		testDeleteVertexLabel("MySchema");
+	}
+	
+	@Test
+	public void testDeleteVertexLabelNoSchema() throws Exception {
+		testDeleteVertexLabel(sqlgGraph.getSqlDialect().getPublicSchema());
+	}
+	
+	private void testDeleteVertexLabel(String schema) throws Exception {
+		try (SqlgGraph sqlgGraph1 = SqlgGraph.open(configuration)) {
+			String A=getLabel(schema,"A");
+			String B=getLabel(schema,"B");
+			String C=getLabel(schema,"C");
+			String D=getLabel(schema,"D");
+			Vertex a = this.sqlgGraph.addVertex(T.label, A, "name", "A");
+			Vertex b = this.sqlgGraph.addVertex(T.label, B, "name", "B");
+			Vertex c = this.sqlgGraph.addVertex(T.label, C, "name", "C", "p1","v1");
+			Vertex d = this.sqlgGraph.addVertex(T.label, D, "name", "D", "p1","v1");
+			a.addEdge("E", b);
+			b.addEdge("E", c);
+			c.addEdge("E", d);
+			
+			//checkVertexLabelBeforeDeletion(sqlgGraph,schema);
+			this.sqlgGraph.tx().commit();
+			checkVertexLabelBeforeDeletion(sqlgGraph,schema);
+			Thread.sleep(1_000);
+			checkVertexLabelBeforeDeletion(sqlgGraph1,schema);
+			
+			
+			TopologyListenerTest tlt=new TopologyListenerTest();
+			this.sqlgGraph.getTopology().registerListener(tlt);
+			
+			VertexLabel lblc=this.sqlgGraph.getTopology().getVertexLabel(schema, "C").get();
+			lblc.remove(false);
+			assertTrue(tlt.receivedEvent(lblc, TopologyChangeAction.DELETE));
+			
+			VertexLabel lbld=this.sqlgGraph.getTopology().getVertexLabel(schema, "D").get();
+			lbld.remove(true);
+			assertTrue(tlt.receivedEvent(lbld, TopologyChangeAction.DELETE));
+			
+			//checkVertexLabelAfterDeletion(sqlgGraph,schema);
+			sqlgGraph.tx().commit();
+			checkVertexLabelAfterDeletion(sqlgGraph,schema);
+			Thread.sleep(1_000);
+			checkVertexLabelAfterDeletion(sqlgGraph1,schema);
+			
+			
+			VertexLabel lblb=this.sqlgGraph.getTopology().getVertexLabel(schema, "B").get();
+			lblb.remove(true);
+			assertTrue(tlt.receivedEvent(lblb, TopologyChangeAction.DELETE));
+			
+			assertFalse(sqlgGraph.getTopology().getEdgeLabel(schema, "E").isPresent());
+			sqlgGraph.tx().commit();
+			assertFalse(sqlgGraph.getTopology().getEdgeLabel(schema, "E").isPresent());
+			Thread.sleep(1_000);
+			assertFalse(sqlgGraph1.getTopology().getEdgeLabel(schema, "E").isPresent());
 		}
 	}
 }

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/topology/TestTopologyDelete.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/topology/TestTopologyDelete.java
@@ -109,7 +109,7 @@ public class TestTopologyDelete extends BaseTest {
                 throw new IllegalArgumentException(String.format("SqlGraph configuration requires that the %s be set", "jdbc.url"));
 
         } catch (ConfigurationException e) {
-            throw new RuntimeException(e);
+            throw new IllegalStateException(e);
         }
     }
 	
@@ -270,12 +270,12 @@ public class TestTopologyDelete extends BaseTest {
 		assertEquals(1L,this.sqlgGraph.topology().V().hasLabel(SQLG_SCHEMA+"."+SQLG_SCHEMA_SCHEMA).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,schema)
 			.out(SQLG_SCHEMA_SCHEMA_VERTEX_EDGE).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,"A")
 			.out(SQLG_SCHEMA_OUT_EDGES_EDGE).has(SQLG_SCHEMA_EDGE_LABEL_NAME,"E")
-			.out(SQLG_SCHEMA_EDGE_PROPERTIES_EDGE).has(Topology.SQLG_SCHEMA_PROPERTY_NAME,"p1").count().next().longValue());
+			.out(SQLG_SCHEMA_EDGE_PROPERTIES_EDGE).has(SQLG_SCHEMA_PROPERTY_NAME,"p1").count().next().longValue());
 			
 		assertEquals(1L,this.sqlgGraph.topology().V().hasLabel(SQLG_SCHEMA+"."+SQLG_SCHEMA_SCHEMA).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,schema)
 				.out(SQLG_SCHEMA_SCHEMA_VERTEX_EDGE).has(SQLG_SCHEMA_VERTEX_LABEL_NAME,"A")
 				.out(SQLG_SCHEMA_OUT_EDGES_EDGE).has(SQLG_SCHEMA_EDGE_LABEL_NAME,"E")
-				.out(SQLG_SCHEMA_EDGE_PROPERTIES_EDGE).has(Topology.SQLG_SCHEMA_PROPERTY_NAME,"p2").count().next().longValue());
+				.out(SQLG_SCHEMA_EDGE_PROPERTIES_EDGE).has(SQLG_SCHEMA_PROPERTY_NAME,"p2").count().next().longValue());
 			
 		assertTrue(columnExistsInSQL(schema, EDGE_PREFIX+"E", "p1"));
 		assertTrue(columnExistsInSQL(schema, EDGE_PREFIX+"E", "p2"));
@@ -952,7 +952,7 @@ public class TestTopologyDelete extends BaseTest {
 		}
 	}
 	
-	private void checkGlobalUniqueIndexBeforeDeletion(SqlgGraph g,String schema,GlobalUniqueIndex gui1,GlobalUniqueIndex gui2) throws Exception {
+	private void checkGlobalUniqueIndexBeforeDeletion(SqlgGraph g,GlobalUniqueIndex gui1,GlobalUniqueIndex gui2) throws Exception {
 		Set<GlobalUniqueIndex> guis=g.getTopology().getGlobalUniqueIndexes();
 		assertNotNull(guis);
 		assertEquals(2,guis.size());
@@ -989,7 +989,7 @@ public class TestTopologyDelete extends BaseTest {
 		assertTrue(tableExistsInSQL(Schema.GLOBAL_UNIQUE_INDEX_SCHEMA, VERTEX_PREFIX+name2));
 	}
 	
-	private void checkGlobalUniqueIndexAfterDeletion(SqlgGraph g,String schema,GlobalUniqueIndex gui1,GlobalUniqueIndex gui2) throws Exception {
+	private void checkGlobalUniqueIndexAfterDeletion(SqlgGraph g,GlobalUniqueIndex gui1,GlobalUniqueIndex gui2) throws Exception {
 		String name1=gui1.getName();
 		String name2=gui2.getName();
 		
@@ -1041,11 +1041,11 @@ public class TestTopologyDelete extends BaseTest {
 	        globalUniqueIndexPropertyColumns.addAll(new HashSet<>(bVertexLabel.getProperties().values()));
 	        GlobalUniqueIndex gui2=this.sqlgGraph.getTopology().ensureGlobalUniqueIndexExist(globalUniqueIndexPropertyColumns);
 	        
-	        checkGlobalUniqueIndexBeforeDeletion(this.sqlgGraph,schema,gui1,gui2);
+	        checkGlobalUniqueIndexBeforeDeletion(this.sqlgGraph,gui1,gui2);
 	        this.sqlgGraph.tx().commit();
-	        checkGlobalUniqueIndexBeforeDeletion(this.sqlgGraph,schema,gui1,gui2);
+	        checkGlobalUniqueIndexBeforeDeletion(this.sqlgGraph,gui1,gui2);
 	        Thread.sleep(1_000);
-	        checkGlobalUniqueIndexBeforeDeletion(sqlgGraph1,schema,gui1,gui2);
+	        checkGlobalUniqueIndexBeforeDeletion(sqlgGraph1,gui1,gui2);
 	        
 	        TopologyListenerTest tlt=new TopologyListenerTest();
 			this.sqlgGraph.getTopology().registerListener(tlt);
@@ -1056,11 +1056,11 @@ public class TestTopologyDelete extends BaseTest {
 	        gui2.remove(true);
 	        assertTrue(tlt.receivedEvent(gui2, TopologyChangeAction.DELETE));
 	        
-	        checkGlobalUniqueIndexAfterDeletion(this.sqlgGraph,schema,gui1,gui2);
+	        checkGlobalUniqueIndexAfterDeletion(this.sqlgGraph,gui1,gui2);
 	        
 	        if (rollback){
 	        	this.sqlgGraph.tx().rollback();
-	        	checkGlobalUniqueIndexBeforeDeletion(this.sqlgGraph,schema,gui1,gui2);
+	        	checkGlobalUniqueIndexBeforeDeletion(this.sqlgGraph,gui1,gui2);
 		        
 	        } else {
 	        
@@ -1068,9 +1068,9 @@ public class TestTopologyDelete extends BaseTest {
 				sqlgGraph1.getTopology().registerListener(tlt1);
 		        
 		        this.sqlgGraph.tx().commit();
-		        checkGlobalUniqueIndexAfterDeletion(this.sqlgGraph,schema,gui1,gui2);
+		        checkGlobalUniqueIndexAfterDeletion(this.sqlgGraph,gui1,gui2);
 		        Thread.sleep(1_000);
-		        checkGlobalUniqueIndexAfterDeletion(sqlgGraph1,schema,gui1,gui2);
+		        checkGlobalUniqueIndexAfterDeletion(sqlgGraph1,gui1,gui2);
 		        assertTrue(tlt1.receivedEvent(gui1, TopologyChangeAction.DELETE));
 		        assertTrue(tlt1.receivedEvent(gui2, TopologyChangeAction.DELETE));
 	        }


### PR DESCRIPTION
This is quite big, it's to be able to delete topology elements. All TopologyInf classes now expose a method remove, with a boolean parameter to indicate if we want to keep the SQL data (usually we won't and pass false, but just in case). There is a test that tries to test the scenarios, including notifications to a different graph and rollbacks. There may be cases I've forgotten, please review!