### PR TITLE
Bugfix/value encoding

### DIFF
--- a/sqlg-postgres-parent/sqlg-postgres-dialect/src/main/java/org/umlg/sqlg/sql/dialect/PostgresDialect.java
+++ b/sqlg-postgres-parent/sqlg-postgres-dialect/src/main/java/org/umlg/sqlg/sql/dialect/PostgresDialect.java
@@ -615,7 +615,7 @@ public class PostgresDialect extends BaseSqlDialect {
                 if (value != null) {
                     ZonedDateTime zonedDateTime = (ZonedDateTime) value;
                     LocalDateTime localDateTime = zonedDateTime.toLocalDateTime();
-                    TimeZone timeZone = TimeZone.getTimeZone(zonedDateTime.getZone().getId());
+                    TimeZone timeZone = TimeZone.getTimeZone(zonedDateTime.getZone());
                     sql.append("'");
                     sql.append(localDateTime.toString());
                     sql.append("'::TIMESTAMP");
@@ -953,7 +953,7 @@ public class PostgresDialect extends BaseSqlDialect {
                     int countStringArray = 1;
                     for (ZonedDateTime zonedDateTime : localZonedDateTimeArray) {
                         LocalDateTime localDateTime = zonedDateTime.toLocalDateTime();
-                        TimeZone timeZone = TimeZone.getTimeZone(zonedDateTime.getZone().getId());
+                        TimeZone timeZone = TimeZone.getTimeZone(zonedDateTime.getZone());
                         sql.append("'");
                         sql.append(localDateTime.toString());
                         sql.append("'::TIMESTAMP");
@@ -966,7 +966,7 @@ public class PostgresDialect extends BaseSqlDialect {
                     countStringArray = 1;
                     for (ZonedDateTime zonedDateTime : localZonedDateTimeArray) {
                         LocalDateTime localDateTime = zonedDateTime.toLocalDateTime();
-                        TimeZone timeZone = TimeZone.getTimeZone(zonedDateTime.getZone().getId());
+                        TimeZone timeZone = TimeZone.getTimeZone(zonedDateTime.getZone());
                         sql.append("'");
                         sql.append(timeZone.getID());
                         sql.append("'");
@@ -1477,7 +1477,7 @@ public class PostgresDialect extends BaseSqlDialect {
                 case ZONEDDATETIME:
                     ZonedDateTime zonedDateTime = (ZonedDateTime) value;
                     LocalDateTime localDateTime = zonedDateTime.toLocalDateTime();
-                    TimeZone timeZone = TimeZone.getTimeZone(zonedDateTime.getZone().getId());
+                    TimeZone timeZone = TimeZone.getTimeZone(zonedDateTime.getZone());
                     result = localDateTime.toString() + COPY_COMMAND_DELIMITER + timeZone.getID();
                     break;
                 case PERIOD:
@@ -1511,7 +1511,7 @@ public class PostgresDialect extends BaseSqlDialect {
                     sb.append("{");
                     for (int i = 0; i < length; i++) {
                         zonedDateTime = zonedDateTimes[i];
-                        timeZone = TimeZone.getTimeZone(zonedDateTime.getZone().getId());
+                        timeZone = TimeZone.getTimeZone(zonedDateTime.getZone());
                         result = timeZone.getID();
                         sb.append(result);
                         if (i < length - 1) {

--- a/sqlg-postgres-parent/sqlg-postgres-dialect/src/main/java/org/umlg/sqlg/sql/dialect/PostgresDialect.java
+++ b/sqlg-postgres-parent/sqlg-postgres-dialect/src/main/java/org/umlg/sqlg/sql/dialect/PostgresDialect.java
@@ -699,7 +699,7 @@ public class PostgresDialect extends BaseSqlDialect {
             case byte_ARRAY:
                 if (value != null) {
                     sql.append("'");
-                    sql.append(PGbytea.toPGString((byte[]) value));
+                    sql.append(PGbytea.toPGString((byte[]) value).replace("'", "''"));
                     sql.append("'");
                 } else {
                     sql.append("null");
@@ -708,7 +708,7 @@ public class PostgresDialect extends BaseSqlDialect {
             case BYTE_ARRAY:
                 if (value != null) {
                     sql.append("'");
-                    sql.append(PGbytea.toPGString((byte[]) SqlgUtil.convertByteArrayToPrimitiveArray((Byte[]) value)));
+                    sql.append(PGbytea.toPGString((byte[]) SqlgUtil.convertByteArrayToPrimitiveArray((Byte[]) value)).replace("'", "''"));
                     sql.append("'");
                 } else {
                     sql.append("null");

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/TestSetProperty.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/TestSetProperty.java
@@ -6,6 +6,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Period;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 
@@ -341,6 +342,10 @@ public class TestSetProperty extends BaseTest {
     	ZonedDateTime zdt=ZonedDateTime.now();
     	v.property("zdt",zdt);
     	    	
+    	ZonedDateTime zdt2=ZonedDateTime.of(LocalDateTime.now(), ZoneId.of("+02:00"));
+    	v.property("zdt2",zdt2);
+    	    	
+    	
     	Period p=Period.ofDays(3);
     	v.property("p", p);
     	
@@ -355,6 +360,7 @@ public class TestSetProperty extends BaseTest {
     	assertProperty(v, "ld", ldt.toLocalDate());
     	assertProperty(v, "lt", lt);
     	assertProperty(v, "zdt", zdt);
+    	assertProperty(v, "zdt2", zdt2);
     	assertProperty(v, "p", p);
     	assertProperty(v, "d", d);
     	Vertex vJ2=sqlgGraph.vertices(vJ.id()).next();
@@ -363,6 +369,7 @@ public class TestSetProperty extends BaseTest {
     	assertProperty(v2, "ld", ldt.toLocalDate());
     	assertProperty(v2, "lt", lt);
     	assertProperty(v2, "zdt", zdt);
+    	assertProperty(v2, "zdt2", zdt2);
     	assertProperty(v2, "p", p);
     	assertProperty(v2, "d", d);
     	
@@ -374,6 +381,7 @@ public class TestSetProperty extends BaseTest {
         	assertProperty(sqlgGraph1, v2, "ld", ldt.toLocalDate());
         	assertProperty(sqlgGraph1, v2, "lt", lt);
         	assertProperty(sqlgGraph1, v2, "zdt", zdt);
+        	assertProperty(sqlgGraph1, v2, "zdt2", zdt2);
         	assertProperty(sqlgGraph1, v2, "p", p);
         	assertProperty(sqlgGraph1, v2, "d", d);
     	}
@@ -383,6 +391,7 @@ public class TestSetProperty extends BaseTest {
         	assertProperty(sqlgGraph1, v2, "ld", ldt.toLocalDate());
         	assertProperty(sqlgGraph1, v2, "lt", lt);
         	assertProperty(sqlgGraph1, v2, "zdt", zdt);
+        	assertProperty(sqlgGraph1, v2, "zdt2", zdt2);
         	assertProperty(sqlgGraph1, v2, "p", p);
         	assertProperty(sqlgGraph1, v2, "d", d);
         	
@@ -394,6 +403,7 @@ public class TestSetProperty extends BaseTest {
         	assertProperty(sqlgGraph1, v2, "ld", ldt.toLocalDate());
         	assertProperty(sqlgGraph1, v2, "lt", lt);
         	assertProperty(sqlgGraph1, v2, "zdt", zdt);
+        	assertProperty(sqlgGraph1, v2, "zdt2", zdt2);
         	assertProperty(sqlgGraph1, v2, "p", p);
         	assertProperty(sqlgGraph1, v2, "d", d);
         	
@@ -416,6 +426,7 @@ public class TestSetProperty extends BaseTest {
     	
     	ZonedDateTime zdt=ZonedDateTime.now();
     	e1.property("zdt",zdt);
+    	
     	    	
     	Period p=Period.ofDays(3);
     	e1.property("p", p);
@@ -454,6 +465,9 @@ public class TestSetProperty extends BaseTest {
     	ZonedDateTime zdt=ZonedDateTime.now();
     	v.property("zdt",new ZonedDateTime[]{zdt});
     	    	
+    	ZonedDateTime zdt2=ZonedDateTime.of(LocalDateTime.now(), ZoneId.of("+02:00"));
+    	v.property("zdt2",new ZonedDateTime[]{zdt2});
+    	
     	Period p=Period.ofDays(3);
     	v.property("p", new Period[]{p});
     	
@@ -465,6 +479,7 @@ public class TestSetProperty extends BaseTest {
     	assertObjectArrayProperty(v, "ld", ldt.toLocalDate());
     	assertObjectArrayProperty(v, "lt", lt);
     	assertObjectArrayProperty(v, "zdt", zdt);
+    	assertObjectArrayProperty(v, "zdt2", zdt2);
     	assertObjectArrayProperty(v, "p", p);
     	assertObjectArrayProperty(v, "d", d);
     }

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/TestSetProperty.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/TestSetProperty.java
@@ -1,5 +1,6 @@
 package org.umlg.sqlg.test;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -49,6 +50,11 @@ public class TestSetProperty extends BaseTest {
         marko.property("bytes", new Byte[]{(byte)1,(byte)2});
         this.sqlgGraph.tx().commit();
         Assert.assertArrayEquals(new Byte[]{(byte)1,(byte)2}, (Byte[]) marko.property("bytes").value());
+        
+        marko.property("bytesText","I pack some weirdness:'\",:/?".getBytes(StandardCharsets.UTF_8));
+        this.sqlgGraph.tx().commit();
+        Assert.assertEquals("I pack some weirdness:'\",:/?", new String((byte[]) marko.property("bytesText").value(),StandardCharsets.UTF_8));
+  
     }
     
     @Test
@@ -112,6 +118,11 @@ public class TestSetProperty extends BaseTest {
         marko.property("bytes", new byte[]{(byte)1,(byte)2});
         this.sqlgGraph.tx().commit();
         Assert.assertArrayEquals(new byte[]{(byte)1,(byte)2}, (byte[]) marko.property("bytes").value());
+        
+        marko.property("bytesText","I pack some weirdness:'\",:/?".getBytes(StandardCharsets.UTF_8));
+        this.sqlgGraph.tx().commit();
+        Assert.assertEquals("I pack some weirdness:'\",:/?", new String((byte[]) marko.property("bytesText").value(),StandardCharsets.UTF_8));
+        
     }
     
     @Test

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/batch/TestBatchNormalDateTime.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/batch/TestBatchNormalDateTime.java
@@ -74,13 +74,22 @@ public class TestBatchNormalDateTime extends BaseTest {
     @Test
     public void testZonedDateTime() throws InterruptedException {
         ZonedDateTime zonedDateTime = ZonedDateTime.now();
+        ZonedDateTime zdt2=ZonedDateTime.of(LocalDateTime.now(), ZoneId.of("+02:00"));
+        // ZoneId corrects +02:00 into GTM+02:00
+        ZonedDateTime zdt2Fixed=ZonedDateTime.of(zdt2.toLocalDateTime(), ZoneId.of("GMT+02:00"));
         this.sqlgGraph.tx().batchMode(BatchManager.BatchModeType.NORMAL);
-        Vertex a1 = this.sqlgGraph.addVertex(T.label, "A", "zonedDateTime", zonedDateTime);
+        Vertex a1 = this.sqlgGraph.addVertex(T.label, "A", "zonedDateTime", zonedDateTime
+        		,"zdt2", zdt2
+        		,"zdt2Fixed", zdt2Fixed);
         this.sqlgGraph.tx().commit();
         Assert.assertEquals(zonedDateTime, this.sqlgGraph.traversal().V(a1).values("zonedDateTime").next());
+        Assert.assertEquals(zdt2Fixed, this.sqlgGraph.traversal().V(a1).values("zdt2").next());
+        Assert.assertEquals(zdt2Fixed, this.sqlgGraph.traversal().V(a1).values("zdt2Fixed").next());
         if (this.sqlgGraph1 != null) {
             Thread.sleep(SLEEP_TIME);
             Assert.assertEquals(zonedDateTime, this.sqlgGraph1.traversal().V(a1).values("zonedDateTime").next());
+            Assert.assertEquals(zdt2Fixed, this.sqlgGraph1.traversal().V(a1).values("zdt2").next());
+            Assert.assertEquals(zdt2Fixed, this.sqlgGraph1.traversal().V(a1).values("zdt2Fixed").next());
         }
     }
 


### PR DESCRIPTION
Fixes a couple of annoying bugs I encountered today. We need to escape quotes properly when we serialize byte arrays, and the zonedatetime handling didn't support zone offsets instead of names. I also wonder why we need to keep the timezone as an extra column. I understand the use case: you can get the data back in the exact timezone it was put in, which may not be your time zone, but is that really useful?