### PR TITLE
Do not delete pids when we get notified of our own actions

### DIFF
--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/Topology.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/Topology.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 import org.apache.commons.collections4.map.HashedMap;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
@@ -60,7 +61,7 @@ public class Topology {
     private Map<String, Map<String, PropertyType>> temporaryTables = new ConcurrentHashMap<>();
 
     //ownPids are the pids to ignore as it is what the graph sent a notification for.
-    private Set<Integer> ownPids = new HashSet<>();
+    private Set<ImmutablePair<Integer, LocalDateTime>> ownPids = Collections.synchronizedSet(new HashSet<>());
 
     //every notification will have a unique timestamp.
     //This is so because modification happen one at a time via the lock.
@@ -387,8 +388,12 @@ public class Topology {
                                 .has(SQLG_SCHEMA_LOG_TIMESTAMP, P.gt(timestamp))
                                 .toList();
                         for (Vertex logVertex : logs) {
-                            ObjectNode log = logVertex.value("log");
-                            fromNotifyJson(timestamp, log);
+                        	int pid=logVertex.value("pid");
+                        	LocalDateTime timestamp2=logVertex.value("timestamp");
+                        	if (!ownPids.contains(new ImmutablePair<>(pid,timestamp2))){
+                        		ObjectNode log = logVertex.value("log");
+                        		fromNotifyJson(timestamp, log);
+                        	}
                         }
                     }
                 }
@@ -692,7 +697,7 @@ public class Topology {
             SqlSchemaChangeDialect sqlSchemaChangeDialect = (SqlSchemaChangeDialect) this.sqlgGraph.getSqlDialect();
             LocalDateTime timestamp = LocalDateTime.now();
             int pid = sqlSchemaChangeDialect.notifyChange(sqlgGraph, timestamp, jsonNodeOptional.get());
-            this.ownPids.add(pid);
+            this.ownPids.add(new ImmutablePair<>(pid,timestamp));
         }
     }
 
@@ -1049,8 +1054,9 @@ public class Topology {
     public void fromNotifyJson(int pid, LocalDateTime notifyTimestamp) {
         z_internalWriteLock();
         try {
-            if (!this.ownPids.contains(pid)) {
-                List<Vertex> logs = this.sqlgGraph.topology().V()
+        	ImmutablePair<Integer,LocalDateTime> p=new ImmutablePair<>(pid,notifyTimestamp);
+            if (!this.ownPids.contains(p)) {
+            	List<Vertex> logs = this.sqlgGraph.topology().V()
                         .hasLabel(SQLG_SCHEMA + "." + SQLG_SCHEMA_LOG)
                         .has(SQLG_SCHEMA_LOG_TIMESTAMP, notifyTimestamp)
                         .toList();
@@ -1062,7 +1068,8 @@ public class Topology {
                 ObjectNode log = logs.get(0).value("log");
                 fromNotifyJson(timestamp, log);
             } else {
-                this.ownPids.remove(pid);
+            	// why? we get notifications for our own things
+                //this.ownPids.remove(p);
             }
         } finally {
             this.sqlgGraph.tx().rollback();

--- a/sqlg-postgres-parent/sqlg-postgres-dialect/src/main/java/org/umlg/sqlg/sql/dialect/PostgresDialect.java
+++ b/sqlg-postgres-parent/sqlg-postgres-dialect/src/main/java/org/umlg/sqlg/sql/dialect/PostgresDialect.java
@@ -3258,7 +3258,9 @@ public class PostgresDialect extends BaseSqlDialect {
     public int notifyChange(SqlgGraph sqlgGraph, LocalDateTime timestamp, JsonNode jsonNode) {
         Connection connection = sqlgGraph.tx().getConnection();
         try {
+        	
             PGConnection pgConnection = connection.unwrap(PGConnection.class);
+            int pid=pgConnection.getBackendPID();
             if (sqlgGraph.tx().isInBatchMode()) {
                 BatchManager.BatchModeType batchModeType = sqlgGraph.tx().getBatchModeType();
                 sqlgGraph.tx().flush();
@@ -3267,7 +3269,7 @@ public class PostgresDialect extends BaseSqlDialect {
                         T.label,
                         SQLG_SCHEMA + "." + SQLG_SCHEMA_LOG,
                         "timestamp", timestamp,
-                        "pid", pgConnection.getBackendPID(),
+                        "pid", pid,
                         "log", jsonNode
                 );
                 sqlgGraph.tx().batchMode(batchModeType);
@@ -3276,14 +3278,14 @@ public class PostgresDialect extends BaseSqlDialect {
                         T.label,
                         SQLG_SCHEMA + "." + SQLG_SCHEMA_LOG,
                         "timestamp", timestamp,
-                        "pid", pgConnection.getBackendPID(),
+                        "pid", pid,
                         "log", jsonNode
                 );
             }
             try (Statement statement = connection.createStatement()) {
                 statement.execute("NOTIFY " + SQLG_NOTIFICATION_CHANNEL + ", '" + timestamp.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME) + "'");
             }
-            return pgConnection.getBackendPID();
+            return pid;
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }

--- a/sqlg-test/src/main/java/org/umlg/sqlg/AllTest.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/AllTest.java
@@ -27,6 +27,7 @@ import org.umlg.sqlg.test.rollback.TestRollback;
 import org.umlg.sqlg.test.schema.*;
 import org.umlg.sqlg.test.topology.TestTopologyChangeListener;
 import org.umlg.sqlg.test.topology.TestTopologyDelete;
+import org.umlg.sqlg.test.topology.TestTopologyDeleteBatch;
 import org.umlg.sqlg.test.topology.TestTopologyMultipleGraphs;
 import org.umlg.sqlg.test.topology.TestTopologyUpgrade;
 import org.umlg.sqlg.test.topology.TestValidateTopology;
@@ -169,7 +170,8 @@ import org.umlg.sqlg.test.vertexstep.localvertexstep.*;
         TestValidateTopology.class,
         TestBatchNormalUpdateDateTimeArrays.class,
         TestTopologyChangeListener.class,
-        TestTopologyDelete.class
+        TestTopologyDelete.class,
+        TestTopologyDeleteBatch.class
 })
 public class AllTest {
 }

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/topology/TestTopologyDeleteBatch.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/topology/TestTopologyDeleteBatch.java
@@ -1,0 +1,44 @@
+package org.umlg.sqlg.test.topology;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.junit.Test;
+import org.umlg.sqlg.structure.Schema;
+import org.umlg.sqlg.structure.SqlgGraph;
+import org.umlg.sqlg.test.BaseTest;
+
+/**
+ * test deletion behavior in a batch
+ * @author JP Moresmau
+ *
+ */
+public class TestTopologyDeleteBatch extends BaseTest {
+
+	@Test
+	public void testSchemaDelete() throws Exception {
+		String schema="willDelete";
+		Vertex v1=sqlgGraph.addVertex(T.label,schema+".t1","name","n1","hello", "world");
+		sqlgGraph.tx().commit();
+		Configuration c= getConfigurationClone();
+		c.setProperty(SqlgGraph.DISTRIBUTED, true);
+		sqlgGraph=SqlgGraph.open(c);
+		sqlgGraph.getTopology().getSchema(schema).ifPresent((Schema s)->s.remove(false));
+		sqlgGraph.tx().commit();
+		
+		v1=sqlgGraph.addVertex(T.label,schema+".t1","name","n1");
+		Vertex v2=sqlgGraph.addVertex(T.label,schema+".t2","name","n2");
+		Edge e1 = v1.addEdge("e1", v2);
+		sqlgGraph.tx().commit();
+		
+		sqlgGraph.tx().normalBatchModeOn();
+		v1.property("hello", "world");
+		
+		e1.property("hello", "world");
+		
+		//sqlgGraph1.getTopology().getSchema(schema).ifPresent((Schema s)->s.remove(false));
+		sqlgGraph.tx().commit();
+		
+	}
+}


### PR DESCRIPTION
this is a bug that bit me in work, caused a NPE in the bottom corners of PostgresDialect. Basically in distributed mode we seem to be notified of our actions, and we may apply a deletion of a schema after we've committed that deletion, and after we've recreated the schema. I fixed it by not removing the pid from our own collection, and also keeping (pid,timestamp) since I'm not sure we can be certain the pid won't change or be reused. this fixed the issue highlighted in the new test and in my work code.