### PR TITLE
order only on last step that has a clause

### DIFF
--- a/sqlg-core/src/main/java/org/umlg/sqlg/sql/parse/SchemaTableTree.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/sql/parse/SchemaTableTree.java
@@ -531,18 +531,29 @@ public class SchemaTableTree {
     private static String constructOuterOrderByClause(SqlgGraph sqlgGraph, List<LinkedList<SchemaTableTree>> subQueryLinkedLists) {
         String result = "";
         int countOuter = 1;
+        // last table list with order as last step wins
+        int winningOrder = 0;
+        for (LinkedList<SchemaTableTree> subQueryLinkedList : subQueryLinkedLists) {
+        	if (!subQueryLinkedList.isEmpty()){
+        		SchemaTableTree schemaTableTree=subQueryLinkedList.peekLast();
+        		if (!schemaTableTree.getDbComparators().isEmpty() 
+        				){
+        			winningOrder=countOuter;
+        		}
+        	}
+        	countOuter++;
+        }
+        countOuter = 1;
         //construct the order by clause for the comparators
         MutableBoolean mutableOrderBy = new MutableBoolean(false);
         for (LinkedList<SchemaTableTree> subQueryLinkedList : subQueryLinkedLists) {
-            int countInner = 1;
-            for (SchemaTableTree schemaTableTree : subQueryLinkedList) {
-                //last entry, only order on the last entry as duplicate paths are for the same SchemaTable
-                if (countOuter == subQueryLinkedLists.size() && countInner == subQueryLinkedList.size()) {
-                    result += schemaTableTree.toOrderByClause(sqlgGraph, mutableOrderBy, countOuter);
-                    result += schemaTableTree.toRangeClause(sqlgGraph, mutableOrderBy);
-                }
-                countInner++;
-            }
+        	if (!subQueryLinkedList.isEmpty()){
+        		SchemaTableTree schemaTableTree=subQueryLinkedList.peekLast();
+        		if (countOuter==winningOrder){
+        			result += schemaTableTree.toOrderByClause(sqlgGraph, mutableOrderBy, countOuter);
+        		}
+        		result += schemaTableTree.toRangeClause(sqlgGraph, mutableOrderBy);
+        	}
             countOuter++;
         }
         return result;

--- a/sqlg-core/src/main/java/org/umlg/sqlg/sql/parse/SchemaTableTree.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/sql/parse/SchemaTableTree.java
@@ -552,6 +552,7 @@ public class SchemaTableTree {
         		if (countOuter==winningOrder){
         			result += schemaTableTree.toOrderByClause(sqlgGraph, mutableOrderBy, countOuter);
         		}
+        		// support range without order
         		result += schemaTableTree.toRangeClause(sqlgGraph, mutableOrderBy);
         	}
             countOuter++;

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/gremlincompile/TestGraphStepOrderBy.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/gremlincompile/TestGraphStepOrderBy.java
@@ -579,6 +579,7 @@ public class TestGraphStepOrderBy extends BaseTest {
             a.addEdge("ab", b);
         }
         this.sqlgGraph.tx().commit();
+        // last one should win
         List<Vertex> vertices = this.sqlgGraph.traversal()
                 .V().hasLabel("A").as("a")
                 .out().order().by("name")


### PR DESCRIPTION
Fixes #231 

Not sure why now diffs show all lines changed. I have autocrlf=true and am on windows.