### PR TITLE
Keep index properties order to be able to retrieve it properly even on long indices

### DIFF
--- a/sqlg-core/src/main/java/org/umlg/sqlg/sql/dialect/SqlDialect.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/sql/dialect/SqlDialect.java
@@ -562,8 +562,8 @@ public interface SqlDialect {
     }
 
     List<String> sqlgTopologyCreationScripts();
-
-    String sqlgAddPropertyIndexTypeColumn();
+    
+    String sqlgAddIndexEdgeSequenceColumn();
 
     default Long getPrimaryKeyStartValue() {
         return 1L;

--- a/sqlg-core/src/main/java/org/umlg/sqlg/strategy/BaseStrategy.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/strategy/BaseStrategy.java
@@ -63,7 +63,7 @@ public abstract class BaseStrategy {
     public static final String PATH_LABEL_SUFFIX = "P~~~";
     public static final String EMIT_LABEL_SUFFIX = "E~~~";
     public static final String SQLG_PATH_FAKE_LABEL = "sqlgPathFakeLabel";
-    private static final String SQLG_PATH_ORDER_RANGE_LABEL = "sqlgPathOrderRangeLabel";
+    public static final String SQLG_PATH_ORDER_RANGE_LABEL = "sqlgPathOrderRangeLabel";
     private static final List<BiPredicate> SUPPORTED_BI_PREDICATE = Arrays.asList(
             Compare.eq, Compare.neq, Compare.gt, Compare.gte, Compare.lt, Compare.lte
     );

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/EdgeLabel.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/EdgeLabel.java
@@ -61,6 +61,14 @@ public class EdgeLabel extends AbstractLabel {
             this.uncommittedOutVertexLabels.add(outVertexLabel);
             this.uncommittedInVertexLabels.add(inVertexLabel);
         }
+        // this is a topology edge label, the columns exist
+        if (forSqlgSchema){
+        	for (PropertyColumn pc:this.uncommittedProperties.values()){
+        		pc.setCommitted(true);
+        		this.properties.put(pc.getName(), pc);
+        	}
+        	this.uncommittedProperties.clear();
+        }
         this.topology = outVertexLabel.getSchema().getTopology();
     }
 

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/Schema.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/Schema.java
@@ -13,6 +13,7 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.umlg.sqlg.sql.dialect.SqlDialect;
+import org.umlg.sqlg.strategy.BaseStrategy;
 
 import java.sql.*;
 import java.time.LocalDateTime;
@@ -805,18 +806,15 @@ public class Schema implements TopologyInf {
      * @param schemaVertex
      */
     void loadVertexIndices(GraphTraversalSource traversalSource, Vertex schemaVertex) {
-        List<Path> indices = traversalSource
-                .V(schemaVertex)
-                .out(SQLG_SCHEMA_SCHEMA_VERTEX_EDGE).as("vertex")
-                //a vertex does not necessarily have properties so use optional.
-                .optional(
-                        __.out(SQLG_SCHEMA_VERTEX_INDEX_EDGE).as("index")
-                                .optional(
-                                        __.out(SQLG_SCHEMA_INDEX_PROPERTY_EDGE).as("property")
-                                )
-                )
-                .path()
-                .toList();
+    	 List<Path> indices = traversalSource
+                 .V(schemaVertex)
+                 .out(SQLG_SCHEMA_SCHEMA_VERTEX_EDGE).as("vertex")
+                 .out(SQLG_SCHEMA_VERTEX_INDEX_EDGE).as("index")
+                 .outE(SQLG_SCHEMA_INDEX_PROPERTY_EDGE)
+                 .order().by(SQLG_SCHEMA_INDEX_PROPERTY_EDGE_SEQUENCE)
+                 .inV().as("property")
+                 .path()
+                 .toList();
         for (Path vertexIndices : indices) {
             Vertex vertexVertex = null;
             Vertex vertexIndex = null;
@@ -834,8 +832,8 @@ public class Schema implements TopologyInf {
                         case "property":
                             propertyIndex = vertexIndices.get("property");
                             break;
-                        case "sqlgPathFakeLabel":
-                            break;
+                        case BaseStrategy.SQLG_PATH_FAKE_LABEL:
+                        case BaseStrategy.SQLG_PATH_ORDER_RANGE_LABEL:
                         case Schema.MARKER:
                             break;
                         default:
@@ -953,16 +951,11 @@ public class Schema implements TopologyInf {
         List<Path> indices = traversalSource
                 .V(schemaVertex)
                 .out(SQLG_SCHEMA_SCHEMA_VERTEX_EDGE).as("vertex")
-                //a vertex does not necessarily have properties so use optional.
-                .optional(
-                        __.out(SQLG_SCHEMA_OUT_EDGES_EDGE).as("outEdgeVertex")
-                                .optional(
-                                        __.out(SQLG_SCHEMA_EDGE_INDEX_EDGE).as("index")
-                                                .optional(
-                                                        __.out(SQLG_SCHEMA_INDEX_PROPERTY_EDGE).as("property")
-                                                )
-                                )
-                )
+                .out(SQLG_SCHEMA_OUT_EDGES_EDGE).as("outEdgeVertex")
+                .out(SQLG_SCHEMA_EDGE_INDEX_EDGE).as("index")
+                .outE(SQLG_SCHEMA_INDEX_PROPERTY_EDGE)
+                .order().by(SQLG_SCHEMA_INDEX_PROPERTY_EDGE_SEQUENCE)
+                .inV().as("property")
                 .path()
                 .toList();
         for (Path vertexIndices : indices) {
@@ -986,8 +979,8 @@ public class Schema implements TopologyInf {
                         case "property":
                             propertyIndex = vertexIndices.get("property");
                             break;
-                        case "sqlgPathFakeLabel":
-                            break;
+                        case BaseStrategy.SQLG_PATH_FAKE_LABEL:
+                        case BaseStrategy.SQLG_PATH_ORDER_RANGE_LABEL:
                         case MARKER:
                             break;
                         default:

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgStartupManager.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgStartupManager.java
@@ -110,7 +110,7 @@ class SqlgStartupManager {
             DatabaseMetaData metadata = conn.getMetaData();
             String catalog = null;
             String schemaPattern = "sqlg_schema";
-            List<Triple<String, Integer, String>> columns = this.sqlDialect.getTableColumns(metadata, catalog, schemaPattern, "E_index_property", Topology.SQLG_SCHEMA_INDEX_PROPERTY_EDGE_SEQUENCE);
+            List<Triple<String, Integer, String>> columns = this.sqlDialect.getTableColumns(metadata, catalog, schemaPattern, "E_index_property", SQLG_SCHEMA_INDEX_PROPERTY_EDGE_SEQUENCE);
             if (columns.isEmpty()) {
                 Statement statement = conn.createStatement();
                 String sql = this.sqlDialect.sqlgAddIndexEdgeSequenceColumn();

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgStartupManager.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgStartupManager.java
@@ -75,8 +75,8 @@ class SqlgStartupManager {
                 logger.debug("Time to upgrade sqlg from pre sqlg_schema: " + stopWatch2.toString());
                 logger.debug("Done upgrading sqlg from pre sqlg_schema version to sqlg_schema version");
             } else {
-                //make sure the property index column exist, this if for upgrading from 1.3.2 to 1.4.0
-                upgradePropertyIndexTypeToExist();
+                // make sure the index edge index property exist, this if for upgrading from 1.3.4 to 1.4.0
+                upgradeIndexEdgeSequenceToExist();
                 this.sqlgGraph.tx().commit();
             }
             cacheTopology();
@@ -103,27 +103,22 @@ class SqlgStartupManager {
             }
         }
     }
-
-    @SuppressWarnings("ConstantConditions")
-    private void upgradePropertyIndexTypeToExist() {
+    
+    private void upgradeIndexEdgeSequenceToExist() {
         Connection conn = this.sqlgGraph.tx().getConnection();
         try {
             DatabaseMetaData metadata = conn.getMetaData();
             String catalog = null;
             String schemaPattern = "sqlg_schema";
-            List<Triple<String, Integer, String>> columns = this.sqlDialect.getTableColumns(metadata, catalog, schemaPattern, "V_property", "index_type");
-            if (!columns.isEmpty()) {
+            List<Triple<String, Integer, String>> columns = this.sqlDialect.getTableColumns(metadata, catalog, schemaPattern, "E_index_property", Topology.SQLG_SCHEMA_INDEX_PROPERTY_EDGE_SEQUENCE);
+            if (columns.isEmpty()) {
                 Statement statement = conn.createStatement();
-                String sql = this.sqlDialect.sqlgAddPropertyIndexTypeColumn();
+                String sql = this.sqlDialect.sqlgAddIndexEdgeSequenceColumn();
                 statement.execute(sql);
             }
-//            ResultSet propertyRs = metadata.getColumns(catalog, schemaPattern, "V_property", "index_type");
-//            if (!propertyRs.next()) {
-//                Statement statement = conn.createStatement();
-//                String sql = this.sqlDialect.sqlgAddPropertyIndexTypeColumn();
-//                statement.execute(sql);
-//            }
+
         } catch (SQLException e) {
+        	e.printStackTrace();
 //            throw new RuntimeException(e);
         }
 

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/Topology.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/Topology.java
@@ -192,6 +192,8 @@ public class Topology {
      */
     @SuppressWarnings("WeakerAccess")
     public static final String SQLG_SCHEMA_INDEX_PROPERTY_EDGE = "index_property";
+
+    public static final String SQLG_SCHEMA_INDEX_PROPERTY_EDGE_SEQUENCE = "sequence";
     /**
      * Table storing the graphs unique property constraints.
      */
@@ -290,31 +292,24 @@ public class Topology {
         this.sqlgSchemaAbstractLabels.add(globalUniqueIndexVertexLabel);
 
         columns.clear();
-        @SuppressWarnings("unused")
         EdgeLabel schemaToVertexEdgeLabel = schemaVertexLabel.loadSqlgSchemaEdgeLabel(SQLG_SCHEMA_SCHEMA_VERTEX_EDGE, vertexVertexLabel, columns);
         this.sqlgSchemaAbstractLabels.add(schemaToVertexEdgeLabel);
-        @SuppressWarnings("unused")
         EdgeLabel vertexInEdgeLabel = vertexVertexLabel.loadSqlgSchemaEdgeLabel(SQLG_SCHEMA_IN_EDGES_EDGE, edgeVertexLabel, columns);
         this.sqlgSchemaAbstractLabels.add(vertexInEdgeLabel);
-        @SuppressWarnings("unused")
         EdgeLabel vertexOutEdgeLabel = vertexVertexLabel.loadSqlgSchemaEdgeLabel(SQLG_SCHEMA_OUT_EDGES_EDGE, edgeVertexLabel, columns);
         this.sqlgSchemaAbstractLabels.add(vertexOutEdgeLabel);
-        @SuppressWarnings("unused")
         EdgeLabel vertexPropertyEdgeLabel = vertexVertexLabel.loadSqlgSchemaEdgeLabel(SQLG_SCHEMA_VERTEX_PROPERTIES_EDGE, propertyVertexLabel, columns);
         this.sqlgSchemaAbstractLabels.add(vertexPropertyEdgeLabel);
-        @SuppressWarnings("unused")
         EdgeLabel edgePropertyEdgeLabel = edgeVertexLabel.loadSqlgSchemaEdgeLabel(SQLG_SCHEMA_EDGE_PROPERTIES_EDGE, propertyVertexLabel, columns);
         this.sqlgSchemaAbstractLabels.add(edgePropertyEdgeLabel);
-        @SuppressWarnings("unused")
         EdgeLabel vertexIndexEdgeLabel = vertexVertexLabel.loadSqlgSchemaEdgeLabel(SQLG_SCHEMA_VERTEX_INDEX_EDGE, indexVertexLabel, columns);
         this.sqlgSchemaAbstractLabels.add(vertexIndexEdgeLabel);
-        @SuppressWarnings("unused")
         EdgeLabel edgeIndexEdgeLabel = edgeVertexLabel.loadSqlgSchemaEdgeLabel(SQLG_SCHEMA_EDGE_INDEX_EDGE, indexVertexLabel, columns);
         this.sqlgSchemaAbstractLabels.add(edgeIndexEdgeLabel);
-        @SuppressWarnings("unused")
+        columns.put(SQLG_SCHEMA_INDEX_PROPERTY_EDGE_SEQUENCE, PropertyType.INTEGER);
         EdgeLabel indexPropertyEdgeLabel = indexVertexLabel.loadSqlgSchemaEdgeLabel(SQLG_SCHEMA_INDEX_PROPERTY_EDGE, propertyVertexLabel, columns);
+        columns.clear();
         this.sqlgSchemaAbstractLabels.add(indexPropertyEdgeLabel);
-        @SuppressWarnings("unused")
         EdgeLabel globalUniqueIndexPropertyEdgeLabel = globalUniqueIndexVertexLabel.loadSqlgSchemaEdgeLabel(SQLG_SCHEMA_GLOBAL_UNIQUE_INDEX_PROPERTY_EDGE, propertyVertexLabel, columns);
         this.sqlgSchemaAbstractLabels.add(globalUniqueIndexPropertyEdgeLabel);
 
@@ -322,7 +317,6 @@ public class Topology {
         columns.put(SQLG_SCHEMA_LOG_TIMESTAMP, PropertyType.LOCALDATETIME);
         columns.put(SQLG_SCHEMA_LOG_LOG, PropertyType.JSON);
         columns.put(SQLG_SCHEMA_LOG_PID, PropertyType.INTEGER);
-        @SuppressWarnings("unused")
         VertexLabel logVertexLabel = sqlgSchema.createSqlgSchemaVertexLabel(SQLG_SCHEMA_LOG, columns);
         this.sqlgSchemaAbstractLabels.add(logVertexLabel);
 

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/TopologyManager.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/TopologyManager.java
@@ -445,6 +445,7 @@ public class TopologyManager {
             } else {
                 abstractLabelVertex.addEdge(SQLG_SCHEMA_EDGE_INDEX_EDGE, indexVertex);
             }
+            int ix=0;
             for (PropertyColumn property : index.getProperties()) {
                 List<Vertex> propertyVertexes = traversalSource.V(abstractLabelVertex)
                         .out(abstractLabel instanceof VertexLabel ? SQLG_SCHEMA_VERTEX_PROPERTIES_EDGE : SQLG_SCHEMA_EDGE_PROPERTIES_EDGE)
@@ -453,7 +454,7 @@ public class TopologyManager {
                 Preconditions.checkState(!propertyVertexes.isEmpty(), "Property %s for AbstractLabel %s.%s does not exists", property.getName(), abstractLabel.getSchema().getName(), abstractLabel.getLabel());
                 Preconditions.checkState(propertyVertexes.size() == 1, "BUG: multiple Properties %s found for AbstractLabels found for %s.%s", property.getName(), abstractLabel.getSchema().getName(), abstractLabel.getLabel());
                 Vertex propertyVertex = propertyVertexes.get(0);
-                indexVertex.addEdge(SQLG_SCHEMA_INDEX_PROPERTY_EDGE, propertyVertex);
+                indexVertex.addEdge(SQLG_SCHEMA_INDEX_PROPERTY_EDGE, propertyVertex,SQLG_SCHEMA_INDEX_PROPERTY_EDGE_SEQUENCE,ix++);
             }
         } finally {
             sqlgGraph.tx().batchMode(batchModeType);
@@ -543,6 +544,7 @@ public class TopologyManager {
 
             boolean createdIndexVertex = false;
             Vertex indexVertex =  null;
+            int ix=0;
             for (String property : properties) {
 
                 List<Vertex> propertyVertexes = traversalSource.V(abstractLabelVertex)
@@ -570,7 +572,7 @@ public class TopologyManager {
                     Preconditions.checkState(propertyVertexes.size() == 1, "BUG: multiple Properties %s found for AbstractLabels found for %s.%s", property, schema, label);
                     Preconditions.checkState(indexVertex != null);
                     Vertex propertyVertex = propertyVertexes.get(0);
-                    indexVertex.addEdge(SQLG_SCHEMA_INDEX_PROPERTY_EDGE, propertyVertex);
+                    indexVertex.addEdge(SQLG_SCHEMA_INDEX_PROPERTY_EDGE, propertyVertex,SQLG_SCHEMA_INDEX_PROPERTY_EDGE_SEQUENCE,ix);
                 }
             }
         } finally {

--- a/sqlg-h2-parent/sqlg-h2-dialect/src/main/java/org/umlg/sqlg/H2Dialect.java
+++ b/sqlg-h2-parent/sqlg-h2-dialect/src/main/java/org/umlg/sqlg/H2Dialect.java
@@ -590,7 +590,7 @@ public class H2Dialect extends BaseSqlDialect {
         result.add("CREATE TABLE IF NOT EXISTS \"sqlg_schema\".\"E_edge_property\"(\"ID\" IDENTITY PRIMARY KEY, \"sqlg_schema.property__I\" BIGINT, \"sqlg_schema.edge__O\" BIGINT, FOREIGN KEY (\"sqlg_schema.property__I\") REFERENCES \"sqlg_schema\".\"V_property\" (\"ID\"),  FOREIGN KEY (\"sqlg_schema.edge__O\") REFERENCES \"sqlg_schema\".\"V_edge\" (\"ID\"));");
         result.add("CREATE TABLE IF NOT EXISTS \"sqlg_schema\".\"E_vertex_index\"(\"ID\" IDENTITY PRIMARY KEY, \"sqlg_schema.index__I\" BIGINT, \"sqlg_schema.vertex__O\" BIGINT, FOREIGN KEY (\"sqlg_schema.index__I\") REFERENCES \"sqlg_schema\".\"V_index\" (\"ID\"), FOREIGN KEY (\"sqlg_schema.vertex__O\") REFERENCES \"sqlg_schema\".\"V_vertex\" (\"ID\"));");
         result.add("CREATE TABLE IF NOT EXISTS \"sqlg_schema\".\"E_edge_index\"(\"ID\" IDENTITY PRIMARY KEY, \"sqlg_schema.index__I\" BIGINT, \"sqlg_schema.edge__O\" BIGINT, FOREIGN KEY (\"sqlg_schema.index__I\") REFERENCES \"sqlg_schema\".\"V_index\" (\"ID\"), FOREIGN KEY (\"sqlg_schema.edge__O\") REFERENCES \"sqlg_schema\".\"V_edge\" (\"ID\"));");
-        result.add("CREATE TABLE IF NOT EXISTS \"sqlg_schema\".\"E_index_property\"(\"ID\" IDENTITY PRIMARY KEY, \"sqlg_schema.property__I\" BIGINT, \"sqlg_schema.index__O\" BIGINT, FOREIGN KEY (\"sqlg_schema.property__I\") REFERENCES \"sqlg_schema\".\"V_property\" (\"ID\"), FOREIGN KEY (\"sqlg_schema.index__O\") REFERENCES \"sqlg_schema\".\"V_index\" (\"ID\"));");
+        result.add("CREATE TABLE IF NOT EXISTS \"sqlg_schema\".\"E_index_property\"(\"ID\" IDENTITY PRIMARY KEY, \"sqlg_schema.property__I\" BIGINT, \"sqlg_schema.index__O\" BIGINT, \"sequence\" INTEGER, FOREIGN KEY (\"sqlg_schema.property__I\") REFERENCES \"sqlg_schema\".\"V_property\" (\"ID\"), FOREIGN KEY (\"sqlg_schema.index__O\") REFERENCES \"sqlg_schema\".\"V_index\" (\"ID\"));");
 
         result.add("CREATE TABLE IF NOT EXISTS \"sqlg_schema\".\"V_log\" (\"ID\" IDENTITY PRIMARY KEY, \"timestamp\" TIMESTAMP, \"pid\" INTEGER, \"log\" VARCHAR);");
 
@@ -598,11 +598,12 @@ public class H2Dialect extends BaseSqlDialect {
         return result;
     }
 
+    
     @Override
-    public String sqlgAddPropertyIndexTypeColumn() {
-        return "";
+    public String sqlgAddIndexEdgeSequenceColumn() {
+        return "ALTER TABLE \"sqlg_schema\".\"E_index_property\" ADD COLUMN \"sequence\" INTEGER DEFAULT 0;";
     }
-
+    
     @Override
     public Object convertArray(PropertyType propertyType, java.sql.Array array) throws SQLException {
         switch (propertyType) {

--- a/sqlg-hsqldb-parent/sqlg-hsqldb-dialect/src/main/java/org/umlg/sqlg/sql/dialect/HsqldbDialect.java
+++ b/sqlg-hsqldb-parent/sqlg-hsqldb-dialect/src/main/java/org/umlg/sqlg/sql/dialect/HsqldbDialect.java
@@ -766,10 +766,12 @@ public class HsqldbDialect extends BaseSqlDialect implements SqlBulkDialect {
         return result;
     }
 
+
     @Override
-    public String sqlgAddPropertyIndexTypeColumn() {
-        return "ALTER TABLE \"sqlg_schema\".\"V_property\" ADD COLUMN \"index_type\" LONGVARCHAR DEFAULT 'NONE';";
+    public String sqlgAddIndexEdgeSequenceColumn() {
+        return "ALTER TABLE \"sqlg_schema\".\"E_index_property\" ADD COLUMN \"sequence\" INTEGER DEFAULT 0;";
     }
+    
 
     @Override
     public Long getPrimaryKeyStartValue() {

--- a/sqlg-mariadb-parent/sqlg-mariadb-dialect/src/main/java/org/umlg/sqlg/sql/dialect/MariadbDialect.java
+++ b/sqlg-mariadb-parent/sqlg-mariadb-dialect/src/main/java/org/umlg/sqlg/sql/dialect/MariadbDialect.java
@@ -716,9 +716,11 @@ public class MariadbDialect extends BaseSqlDialect {
         return result;
     }
 
+
     @Override
-    public String sqlgAddPropertyIndexTypeColumn() {
-        return "ALTER TABLE \"sqlg_schema\".\"V_property\" ADD COLUMN \"index_type\" LONGVARCHAR DEFAULT 'NONE';";
+    public String sqlgAddIndexEdgeSequenceColumn() {
+        return "ALTER TABLE \"sqlg_schema\".\"E_index_property\" ADD COLUMN \"sequence\" INTEGER DEFAULT 0;";
+        
     }
 
     private Array createArrayOf(Connection conn, PropertyType propertyType, Object[] data) {

--- a/sqlg-mssqlserver-parent/sqlg-mssqlserver-dialect/src/main/java/org/umlg/sqlg/mssqlserver/MSSqlServerDialect.java
+++ b/sqlg-mssqlserver-parent/sqlg-mssqlserver-dialect/src/main/java/org/umlg/sqlg/mssqlserver/MSSqlServerDialect.java
@@ -537,9 +537,11 @@ public class MSSqlServerDialect extends BaseSqlDialect {
         return result;
     }
 
+
     @Override
-    public String sqlgAddPropertyIndexTypeColumn() {
-        return "ALTER TABLE \"sqlg_schema\".\"V_property\" ADD \"index_type\" TEXT DEFAULT 'NONE';";
+    public String sqlgAddIndexEdgeSequenceColumn() {
+        return "ALTER TABLE \"sqlg_schema\".\"E_index_property\" ADD COLUMN \"sequence\" INTEGER DEFAULT 0;";
+        
     }
 
     @Override

--- a/sqlg-postgres-parent/sqlg-postgres-dialect/src/main/java/org/umlg/sqlg/sql/dialect/PostgresDialect.java
+++ b/sqlg-postgres-parent/sqlg-postgres-dialect/src/main/java/org/umlg/sqlg/sql/dialect/PostgresDialect.java
@@ -2820,7 +2820,7 @@ public class PostgresDialect extends BaseSqlDialect implements SqlBulkDialect {
         result.add("CREATE INDEX IF NOT EXISTS \"E_edge_index_index__I_idx\" ON \"sqlg_schema\".\"E_edge_index\" (\"sqlg_schema.index__I\");");
         result.add("CREATE INDEX IF NOT EXISTS \"E_edge_index_vertex__O_idx\" ON \"sqlg_schema\".\"E_edge_index\" (\"sqlg_schema.edge__O\");");
 
-        result.add("CREATE TABLE IF NOT EXISTS \"sqlg_schema\".\"E_index_property\"(\"ID\" SERIAL PRIMARY KEY, \"sqlg_schema.property__I\" BIGINT, \"sqlg_schema.index__O\" BIGINT, FOREIGN KEY (\"sqlg_schema.property__I\") REFERENCES \"sqlg_schema\".\"V_property\" (\"ID\"), FOREIGN KEY (\"sqlg_schema.index__O\") REFERENCES \"sqlg_schema\".\"V_index\" (\"ID\"));");
+        result.add("CREATE TABLE IF NOT EXISTS \"sqlg_schema\".\"E_index_property\"(\"ID\" SERIAL PRIMARY KEY, \"sqlg_schema.property__I\" BIGINT, \"sqlg_schema.index__O\" BIGINT, \"sequence\" INTEGER, FOREIGN KEY (\"sqlg_schema.property__I\") REFERENCES \"sqlg_schema\".\"V_property\" (\"ID\"), FOREIGN KEY (\"sqlg_schema.index__O\") REFERENCES \"sqlg_schema\".\"V_index\" (\"ID\"));");
         result.add("CREATE INDEX IF NOT EXISTS \"E_index_property_property__I_idx\" ON \"sqlg_schema\".\"E_index_property\" (\"sqlg_schema.property__I\");");
         result.add("CREATE INDEX IF NOT EXISTS \"E_index_property_index__O_idx\" ON \"sqlg_schema\".\"E_index_property\" (\"sqlg_schema.index__O\");");
 
@@ -2832,8 +2832,9 @@ public class PostgresDialect extends BaseSqlDialect implements SqlBulkDialect {
     }
 
     @Override
-    public String sqlgAddPropertyIndexTypeColumn() {
-        return "ALTER TABLE \"sqlg_schema\".\"V_property\" ADD COLUMN \"index_type\" TEXT DEFAULT 'NONE';";
+    public String sqlgAddIndexEdgeSequenceColumn() {
+        return "ALTER TABLE \"sqlg_schema\".\"E_index_property\" ADD COLUMN \"sequence\" INTEGER DEFAULT 0;";
+        
     }
 
     private Array createArrayOf(Connection conn, PropertyType propertyType, Object[] data) {

--- a/sqlg-postgres-parent/sqlg-postgres-dialect/src/main/java/org/umlg/sqlg/sql/dialect/PostgresDialect.java
+++ b/sqlg-postgres-parent/sqlg-postgres-dialect/src/main/java/org/umlg/sqlg/sql/dialect/PostgresDialect.java
@@ -575,7 +575,7 @@ public class PostgresDialect extends BaseSqlDialect implements SqlBulkDialect {
             case STRING:
                 if (value != null) {
                     sql.append("'");
-                    sql.append(value.toString().replace("'", "''"));
+                    sql.append(escapeQuotes(value));
                     sql.append("'");
                 } else {
                     sql.append("null");
@@ -655,7 +655,7 @@ public class PostgresDialect extends BaseSqlDialect implements SqlBulkDialect {
             case JSON:
                 if (value != null) {
                     sql.append("'");
-                    sql.append(value.toString().replace("'", "''"));
+                    sql.append(escapeQuotes(value));
                     sql.append("'::JSONB");
                 } else {
                     sql.append("null");
@@ -696,7 +696,7 @@ public class PostgresDialect extends BaseSqlDialect implements SqlBulkDialect {
             case byte_ARRAY:
                 if (value != null) {
                     sql.append("'");
-                    sql.append(PGbytea.toPGString((byte[]) value).replace("'", "''"));
+                    sql.append(escapeQuotes(PGbytea.toPGString((byte[]) value)));
                     sql.append("'");
                 } else {
                     sql.append("null");
@@ -705,7 +705,7 @@ public class PostgresDialect extends BaseSqlDialect implements SqlBulkDialect {
             case BYTE_ARRAY:
                 if (value != null) {
                     sql.append("'");
-                    sql.append(PGbytea.toPGString((byte[]) SqlgUtil.convertByteArrayToPrimitiveArray((Byte[]) value)).replace("'", "''"));
+                    sql.append(escapeQuotes(PGbytea.toPGString((byte[]) SqlgUtil.convertByteArrayToPrimitiveArray((Byte[]) value))));
                     sql.append("'");
                 } else {
                     sql.append("null");
@@ -3366,23 +3366,23 @@ public class PostgresDialect extends BaseSqlDialect implements SqlBulkDialect {
                 sb = toValuesArray(this.propertyTypeToSqlDefinition(propertyType)[0], value);
                 return sb.toString();
             case STRING:
-                return "'" + value.toString() + "'" + "::" + this.propertyTypeToSqlDefinition(propertyType)[0];
+                return "'" + escapeQuotes(value) + "'" + "::" + this.propertyTypeToSqlDefinition(propertyType)[0];
             case STRING_ARRAY:
                 sb = toValuesArray(this.propertyTypeToSqlDefinition(propertyType)[0], value);
                 return sb.toString();
             case LOCALDATE:
-                return "'" + value.toString() + "'" + "::" + this.propertyTypeToSqlDefinition(propertyType)[0];
+                return "'" + escapeQuotes(value) + "'" + "::" + this.propertyTypeToSqlDefinition(propertyType)[0];
             case LOCALDATE_ARRAY:
                 sb = toValuesArray(this.propertyTypeToSqlDefinition(propertyType)[0], value);
                 return sb.toString();
             case LOCALDATETIME:
-                return "'" + value.toString() + "'" + "::" + this.propertyTypeToSqlDefinition(propertyType)[0];
+                return "'" + escapeQuotes(value) + "'" + "::" + this.propertyTypeToSqlDefinition(propertyType)[0];
             case LOCALDATETIME_ARRAY:
                 sb = toValuesArray(this.propertyTypeToSqlDefinition(propertyType)[0], value);
                 return sb.toString();
             case LOCALTIME:
                 LocalTime lt = (LocalTime) value;
-                return "'" + shiftDST(lt).toString() + "'" + "::" + this.propertyTypeToSqlDefinition(propertyType)[0];
+                return "'" + escapeQuotes(shiftDST(lt)) + "'" + "::" + this.propertyTypeToSqlDefinition(propertyType)[0];
             case LOCALTIME_ARRAY:
                 sb = new StringBuilder();
                 sb.append("'{");
@@ -3410,7 +3410,7 @@ public class PostgresDialect extends BaseSqlDialect implements SqlBulkDialect {
             case DURATION_ARRAY:
                 throw new IllegalStateException("DURATION_ARRAY is not supported in within.");
             case JSON:
-                return "'" + value.toString() + "'" + "::" + this.propertyTypeToSqlDefinition(propertyType)[0];
+                return "'" + escapeQuotes(value) + "'" + "::" + this.propertyTypeToSqlDefinition(propertyType)[0];
             case JSON_ARRAY:
                 sb = new StringBuilder();
                 sb.append("'{");
@@ -3418,7 +3418,7 @@ public class PostgresDialect extends BaseSqlDialect implements SqlBulkDialect {
                 for (int i = 0; i < length; i++) {
                     String valueOfArray = java.lang.reflect.Array.get(value, i).toString();
                     sb.append("\"");
-                    sb.append(valueOfArray.replace("\"", "\\\""));
+                    sb.append( escapeQuotes(valueOfArray.replace("\"", "\\\"")));
                     sb.append("\"");
                     if (i < length - 1) {
                         sb.append(",");
@@ -3428,15 +3428,15 @@ public class PostgresDialect extends BaseSqlDialect implements SqlBulkDialect {
                 sb.append(this.propertyTypeToSqlDefinition(propertyType)[0]);
                 return sb.toString();
             case POINT:
-                return "'" + value.toString() + "'" + "::" + this.propertyTypeToSqlDefinition(propertyType)[0];
+                return "'" + escapeQuotes(value) + "'" + "::" + this.propertyTypeToSqlDefinition(propertyType)[0];
             case LINESTRING:
-                return "'" + value.toString() + "'" + "::" + this.propertyTypeToSqlDefinition(propertyType)[0];
+                return "'" + escapeQuotes(value) + "'" + "::" + this.propertyTypeToSqlDefinition(propertyType)[0];
             case POLYGON:
-                return "'" + value.toString() + "'" + "::" + this.propertyTypeToSqlDefinition(propertyType)[0];
+                return "'" + escapeQuotes(value) + "'" + "::" + this.propertyTypeToSqlDefinition(propertyType)[0];
             case GEOGRAPHY_POINT:
-                return "'" + value.toString() + "'" + "::" + this.propertyTypeToSqlDefinition(propertyType)[0];
+                return "'" + escapeQuotes(value) + "'" + "::" + this.propertyTypeToSqlDefinition(propertyType)[0];
             case GEOGRAPHY_POLYGON:
-                return "'" + value.toString() + "'" + "::" + this.propertyTypeToSqlDefinition(propertyType)[0];
+                return "'" + escapeQuotes(value) + "'" + "::" + this.propertyTypeToSqlDefinition(propertyType)[0];
             default:
                 throw SqlgExceptions.invalidPropertyType(propertyType);
         }
@@ -3552,5 +3552,17 @@ public class PostgresDialect extends BaseSqlDialect implements SqlBulkDialect {
     @Override
     public int sqlInParameterLimit() {
         return PARAMETER_LIMIT;
+    }
+    
+    /**
+     * escape quotes by doubling them when we need a string inside quotes
+     * @param o
+     * @return
+     */
+    private String escapeQuotes(Object o){
+    	if (o!=null){
+	    	return o.toString().replace("'", "''");
+	    }
+    	return null;
     }
 }

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/edges/TestOutE.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/edges/TestOutE.java
@@ -1,5 +1,14 @@
 package org.umlg.sqlg.test.edges;
 
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Order;
+import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.apache.tinkerpop.gremlin.process.traversal.Path;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Assert;
@@ -24,4 +33,59 @@ public class TestOutE extends BaseTest {
         Assert.assertEquals(1, this.sqlgGraph.traversal().V().has("name", "p").outE("aaa").count().next().intValue());
     }
 
+	@Test
+    public void testOutEWithAttributes() throws Exception {
+	    Vertex v1 = this.sqlgGraph.addVertex(T.label, "Person", "name", "p1");
+        Vertex v2 = this.sqlgGraph.addVertex(T.label, "Person", "name", "p2");
+        Vertex v3 = this.sqlgGraph.addVertex(T.label, "Person", "name", "p3");
+        Vertex v4 = this.sqlgGraph.addVertex(T.label, "Person", "name", "p4");
+        Vertex v5 = this.sqlgGraph.addVertex(T.label, "Person", "name", "p5");
+        
+        v1.addEdge("aaa", v2,"real",true);
+        v1.addEdge("aaa", v3,"real",false);
+        v1.addEdge("aaa", v4,"real",true,"other","one");
+        v1.addEdge("aaa", v5,"real",false);
+        
+        this.sqlgGraph.tx().commit();
+        GraphTraversal<Vertex, Vertex> gt=vertexTraversal(this.sqlgGraph, v1).outE()
+               		.where(__.inV().has("name",P.within("p4","p2")))
+               		.inV();
+        assertEquals(2,gt.count().next().intValue());
+        gt.close();
+       
+	}
+	
+	@Test
+	public void testOutEOrder()throws Exception {
+	    Vertex v1 = this.sqlgGraph.addVertex(T.label, "Person", "name", "p1");
+        Vertex v2 = this.sqlgGraph.addVertex(T.label, "Person", "name", "p2");
+        Vertex v3 = this.sqlgGraph.addVertex(T.label, "Person", "name", "p3");
+        Vertex v4 = this.sqlgGraph.addVertex(T.label, "Person", "name", "p4");
+        Vertex v5 = this.sqlgGraph.addVertex(T.label, "Person", "name", "p5");
+        v1.addEdge("e1", v2);
+        v2.addEdge("e2", v3);
+        v3.addEdge("e3", v4,"sequence",1);
+        v3.addEdge("e3", v5,"sequence",2);
+        
+        
+        this.sqlgGraph.tx().commit();
+        List<Path> ps=vertexTraversal(this.sqlgGraph, v1)
+        	.out("e1").as("v2")
+        	.out("e2").as("v3")
+        	.outE("e3").order().by("sequence")
+        	.inV().as("v4-5").path().toList();
+        assertEquals(2,ps.size());
+        assertEquals(v4,ps.get(0).get("v4-5"));
+        assertEquals(v5,ps.get(1).get("v4-5"));
+        
+        ps=vertexTraversal(this.sqlgGraph, v1)
+            	.out("e1").as("v2")
+            	.out("e2").as("v3")
+            	.outE("e3").order().by("sequence",Order.decr)
+            	.inV().as("v4-5").path().toList();
+        assertEquals(2,ps.size());
+        assertEquals(v4,ps.get(1).get("v4-5"));
+        assertEquals(v5,ps.get(0).get("v4-5"));
+            
+	}
 }

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/gremlincompile/TestGraphStepOrderBy.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/gremlincompile/TestGraphStepOrderBy.java
@@ -3,6 +3,7 @@ package org.umlg.sqlg.test.gremlincompile;
 import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.DefaultGraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.T;
@@ -591,6 +592,24 @@ public class TestGraphStepOrderBy extends BaseTest {
         Assert.assertEquals("b1", vertices.get(1).value("name"));
         Assert.assertEquals("b0", vertices.get(2).value("name"));
         Assert.assertEquals("b0", vertices.get(3).value("name"));
+    }
+    
+    @Test
+    public void testOutEOrderID(){
+    	 Vertex a = this.sqlgGraph.addVertex(T.label, "A", "name", "a");
+    	 for (int i = 0; i < 2; i++) {
+             Vertex b = this.sqlgGraph.addVertex(T.label, "B", "name", "b" + i);
+             a.addEdge("ab", b);
+         }
+         this.sqlgGraph.tx().commit();
+         GraphTraversal<Vertex, Map<String,Object>> gt=this.sqlgGraph.traversal().V().hasLabel("A").as("a")
+         	.outE("ab").order().by(T.id).as("e")
+         	.inV().as("b")
+         	.select("a","e","b");
+         while (gt.hasNext()){
+        	 Map<String,Object> m=gt.next();
+        	 assertEquals(a,m.get("a"));
+         }
     }
 
 }

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/index/TestIndex.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/index/TestIndex.java
@@ -323,4 +323,60 @@ public class TestIndex extends BaseTest {
         Assert.assertEquals(IndexType.NON_UNIQUE, it2);
 
     }
+    
+    @Test
+    public void testLongIndexName() throws Exception {
+    	String i1=buildLongIndex(sqlgGraph);
+    	String i2=buildLongIndex(sqlgGraph);
+    	assertEquals(i1,i2);
+    	sqlgGraph.close();
+    	sqlgGraph=SqlgGraph.open(getConfigurationClone());
+    	String i3=buildLongIndex(sqlgGraph);
+    	assertEquals(i1,i3);
+    }
+    
+    private String buildLongIndex(SqlgGraph g){
+    	Schema sch=g.getTopology().ensureSchemaExist("longIndex");
+    	Map<String,PropertyType> columns=new HashMap<String, PropertyType>();
+    	columns.put("longpropertyname1",PropertyType.STRING);
+    	columns.put("longpropertyname2",PropertyType.STRING);
+    	columns.put("longpropertyname3",PropertyType.STRING);
+    	VertexLabel label=sch.ensureVertexLabelExist("LongIndex", columns);
+    	List<PropertyColumn> properties=Arrays.asList(
+    			label.getProperty("longpropertyname1").get()
+    			,label.getProperty("longpropertyname2").get()
+    			,label.getProperty("longpropertyname3").get());
+    	Index idx=label.ensureIndexExists(IndexType.NON_UNIQUE, properties);
+    	
+    	g.tx().commit();
+    	return idx.getName();
+    }
+    
+    @Test
+    public void testShortIndexName() throws Exception {
+    	String i1=buildShortIndex(sqlgGraph);
+    	String i2=buildShortIndex(sqlgGraph);
+    	assertEquals(i1,i2);
+    	sqlgGraph.close();
+    	sqlgGraph=SqlgGraph.open(getConfigurationClone());
+    	String i3=buildShortIndex(sqlgGraph);
+    	assertEquals(i1,i3);
+    }
+    
+    private String buildShortIndex(SqlgGraph g){
+    	Schema sch=g.getTopology().ensureSchemaExist("longIndex");
+    	Map<String,PropertyType> columns=new HashMap<String, PropertyType>();
+    	columns.put("short1",PropertyType.STRING);
+    	columns.put("short2",PropertyType.STRING);
+    	columns.put("short3",PropertyType.STRING);
+    	VertexLabel label=sch.ensureVertexLabelExist("LongIndex", columns);
+    	List<PropertyColumn> properties=Arrays.asList(
+    			label.getProperty("short1").get()
+    			,label.getProperty("short2").get()
+    			,label.getProperty("short3").get());
+    	Index idx=label.ensureIndexExists(IndexType.NON_UNIQUE, properties);
+    	
+    	g.tx().commit();
+    	return idx.getName();
+    }
 }

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/properties/TestEscapedValues.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/properties/TestEscapedValues.java
@@ -8,7 +8,7 @@ import org.umlg.sqlg.test.BaseTest;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Test values that are escaped by backslashes
+ * Test values that are escaped by backslashes and that may impact SQL
  * @author jpmoresmau
  *
  */
@@ -16,7 +16,7 @@ public class TestEscapedValues extends BaseTest {
 
 	@Test
 	public void testEscapedValuesSingleQuery(){
-		String[] vals = new String[] { "x-y", "x\ny", "x\"y", "x\\y", "x\\ny", "x\\\"y" };
+		String[] vals = new String[] { "x-y", "x\ny", "x\"y", "x\\y", "x\\ny", "x\\\"y", "'x'y'" };
 		for (String s : vals) {
 			this.sqlgGraph.addVertex("Escaped").property("name", s);
 		}
@@ -29,7 +29,7 @@ public class TestEscapedValues extends BaseTest {
 	
 	@Test
 	public void testEscapedValuesWithinQuery(){
-		String[] vals = new String[] { "x-y", "x\ny", "x\"y", "x\\y", "x\\ny", "x\\\"y" };
+		String[] vals = new String[] { "x-y", "x\ny", "x\"y", "x\\y", "x\\ny", "x\\\"y", "'x'y'"  };
 		for (String s : vals) {
 			this.sqlgGraph.addVertex("Escaped").property("name", s); 
 		}
@@ -43,7 +43,7 @@ public class TestEscapedValues extends BaseTest {
 	public void testEscapedValuesSingleQueryBatch(){
 		Assume.assumeTrue(this.sqlgGraph.getSqlDialect().supportsBatchMode());
 		this.sqlgGraph.tx().normalBatchModeOn();
-		String[] vals = new String[] { "x-y", "x\ny", "x\"y", "x\\y", "x\\ny", "x\\\"y" };
+		String[] vals = new String[] { "x-y", "x\ny", "x\"y", "x\\y", "x\\ny", "x\\\"y", "'x'y'" };
 		for (String s : vals) {
 			this.sqlgGraph.addVertex("Escaped").property("name", s);
 		}


### PR DESCRIPTION
Went a bit down the rabbit hole on that one.

- Started with an issue on indices moving from 1.3 to 1.4. It went away when I wiped out my old sqlg_schema, but I investigated. On indices with long names, now we generate always a random name, so every ensureIndexExists creates a new one! We now check on the list of properties in that case.
- This failed because we didn't retrieve the list of properties in order. So I added an edge property called sequence between index and property.
- This caused loads of issues, because of a bug in Topology loading, edge properties were uncommitted instead of committed
- I added some upgrade code for that new column I added, and found we had old upgrade code creating a column we don't use any more, I just removed it

I've added a couple of tests for all of this and all tests pass on Postgres.  (well apart of 2 datetime tests that assume we all live in South Africa :-))

There is still some issue where if you do an order by an non existing property, you get a NPE instead of a better message (or silently dropping the order by?)