### PR TITLE
fixed testDateTimeProperties expected Africa/Johannesburg

### DIFF
--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/TestSetProperty.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/TestSetProperty.java
@@ -333,7 +333,7 @@ public class TestSetProperty extends BaseTest {
         LocalTime lt = ldt.toLocalTime().truncatedTo(ChronoUnit.SECONDS);
         v.property("lt", lt);
 
-        ZonedDateTime zdt = ZonedDateTime.now();
+        ZonedDateTime zdt = ZonedDateTime.of(LocalDateTime.now(), ZoneId.of("Africa/Johannesburg"));
         ZonedDateTime zdt1Fixed = ZonedDateTime.of(zdt.toLocalDateTime(), ZoneId.of("Africa/Johannesburg"));
         v.property("zdt", zdt);
 


### PR DESCRIPTION
ZonedDateTime generated at testDateTimeProperties.java expected zone of Africa/Johannesburg actual zone could be any