### PR TITLE
faster maven testing in travis and locally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ jdk:
 #script: "./run-tests.sh"
 script:
   - sudo rm /etc/mavenrc
-  - export MAVEN_OPTS="-Xmx5012m"
-  - mvn -e test
+  - export MAVEN_OPTS="-Djava.security.egd=file:/dev/./urandom -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xmx5012m"
+  - mvn -e -T40 test
 addons:
   postgresql: "9.6"
 before_script:

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 
-#mvn -q test
-mvn -e -X test
+export MAVEN_OPTS=" -Djava.security.egd=file:/dev/./urandom -XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+
+#mvn -T40 -q test
+mvn -T40 -e -X test


### PR DESCRIPTION
added -T40 option to mvn into `run-tests.sh` and `.travis.yml` meaning run mvn in parallel with 40 threads per core (optimal core count is between 36-45 in JVM based languages).

added 
```
-Djava.security.egd=file:/dev/./urandom -XX:+TieredCompilation -XX:TieredStopAtLevel=1
```

MAVEN_OPTS into `run-tests.sh` and `.travis.yml` as a standard maven speedup optimization arguments.