### PR TITLE
Internal/static logger 1.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ src/test/db/
 **/.classpath
 **/.project
 **/.settings
+/.metadata
+/.recommenders

--- a/sqlg-cockroachdb-parent/sqlg-cockroachdb-dialect/src/main/java/org/umlg/sqlg/sql/dialect/CockroachdbDialect.java
+++ b/sqlg-cockroachdb-parent/sqlg-cockroachdb-dialect/src/main/java/org/umlg/sqlg/sql/dialect/CockroachdbDialect.java
@@ -1,9 +1,39 @@
 package org.umlg.sqlg.sql.dialect;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
+import static org.umlg.sqlg.structure.PropertyType.BOOLEAN_ARRAY;
+import static org.umlg.sqlg.structure.PropertyType.BYTE_ARRAY;
+import static org.umlg.sqlg.structure.PropertyType.SHORT_ARRAY;
+import static org.umlg.sqlg.structure.topology.Topology.EDGE_PREFIX;
+import static org.umlg.sqlg.structure.topology.Topology.VERTEX_PREFIX;
+
+import java.io.IOException;
+import java.sql.Array;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Period;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.TimeZone;
+
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Triple;
@@ -14,18 +44,19 @@ import org.postgresql.util.PGobject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.umlg.sqlg.predicate.FullText;
-import org.umlg.sqlg.structure.*;
+import org.umlg.sqlg.structure.PropertyType;
+import org.umlg.sqlg.structure.RecordId;
+import org.umlg.sqlg.structure.SchemaTable;
+import org.umlg.sqlg.structure.SqlgExceptions;
+import org.umlg.sqlg.structure.SqlgGraph;
+import org.umlg.sqlg.structure.SqlgVertex;
 import org.umlg.sqlg.structure.topology.Topology;
 import org.umlg.sqlg.util.SqlgUtil;
 
-import java.io.IOException;
-import java.sql.*;
-import java.sql.Date;
-import java.time.*;
-import java.util.*;
-
-import static org.umlg.sqlg.structure.PropertyType.*;
-import static org.umlg.sqlg.structure.topology.Topology.*;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
 
 /**
  * @author Pieter Martin (https://github.com/pietermartin)
@@ -35,7 +66,7 @@ import static org.umlg.sqlg.structure.topology.Topology.*;
 public class CockroachdbDialect extends BaseSqlDialect {
 
     private static final int PARAMETER_LIMIT = 32767;
-    private Logger logger = LoggerFactory.getLogger(CockroachdbDialect.class.getName());
+    private static Logger logger = LoggerFactory.getLogger(CockroachdbDialect.class);
 
     public CockroachdbDialect() {
         super();

--- a/sqlg-core/src/main/java/org/umlg/sqlg/predicate/FullText.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/predicate/FullText.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
  *
  */
 public class FullText implements BiPredicate<String, String> {
-	private static Logger logger = LoggerFactory.getLogger(FullText.class.getName());
+	private static Logger logger = LoggerFactory.getLogger(FullText.class);
 	/**
 	 * full text configuration to use
 	 */

--- a/sqlg-core/src/main/java/org/umlg/sqlg/step/SqlgVertexStep.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/step/SqlgVertexStep.java
@@ -24,7 +24,7 @@ import java.util.*;
  */
 public class SqlgVertexStep<E extends SqlgElement> extends SqlgAbstractStep implements SqlgStep {
 
-    private static Logger logger = LoggerFactory.getLogger(SqlgVertexStep.class.getName());
+    private static Logger logger = LoggerFactory.getLogger(SqlgVertexStep.class);
     private SqlgGraph sqlgGraph;
 
     //This holds the head/start traversers per SchemaTable.

--- a/sqlg-core/src/main/java/org/umlg/sqlg/strategy/GraphStrategy.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/strategy/GraphStrategy.java
@@ -26,7 +26,7 @@ import java.util.stream.Stream;
  */
 public class GraphStrategy extends BaseStrategy {
 
-    private Logger logger = LoggerFactory.getLogger(GraphStrategy.class.getName());
+    private static Logger logger = LoggerFactory.getLogger(GraphStrategy.class);
 
     private GraphStrategy(Traversal.Admin<?, ?> traversal) {
         super(traversal);

--- a/sqlg-core/src/main/java/org/umlg/sqlg/strategy/SqlgSqlExecutor.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/strategy/SqlgSqlExecutor.java
@@ -25,7 +25,7 @@ import java.util.Set;
  */
 public class SqlgSqlExecutor {
 
-    private static Logger logger = LoggerFactory.getLogger(SqlgSqlExecutor.class.getName());
+    private static Logger logger = LoggerFactory.getLogger(SqlgSqlExecutor.class);
 
     private SqlgSqlExecutor() {
     }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/strategy/VertexStrategy.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/strategy/VertexStrategy.java
@@ -27,7 +27,7 @@ import java.util.ListIterator;
  */
 public class VertexStrategy extends BaseStrategy {
 
-    private Logger logger = LoggerFactory.getLogger(VertexStrategy.class.getName());
+    private static Logger logger = LoggerFactory.getLogger(VertexStrategy.class);
 
     public VertexStrategy(Traversal.Admin<?, ?> traversal) {
         super(traversal);

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgEdge.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgEdge.java
@@ -23,7 +23,7 @@ import static org.umlg.sqlg.structure.topology.Topology.EDGE_PREFIX;
  */
 public class SqlgEdge extends SqlgElement implements Edge {
 
-    private Logger logger = LoggerFactory.getLogger(SqlgEdge.class.getName());
+    private static Logger logger = LoggerFactory.getLogger(SqlgEdge.class);
     private SqlgVertex inVertex;
     private SqlgVertex outVertex;
 

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgElement.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgElement.java
@@ -28,7 +28,7 @@ import static org.umlg.sqlg.structure.topology.Topology.VERTEX_PREFIX;
  */
 public abstract class SqlgElement implements Element {
 
-    private Logger logger = LoggerFactory.getLogger(SqlgVertex.class.getName());
+    private static Logger logger = LoggerFactory.getLogger(SqlgVertex.class);
 
     protected String schema;
     protected String table;

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgGraph.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgGraph.java
@@ -185,7 +185,7 @@ public class SqlgGraph implements Graph {
     public static final String MODE_FOR_STREAM_VERTEX = " mode for streamVertex";
     public static final String TRANSACTION_MUST_BE_IN = "Transaction must be in ";
     private final SqlgDataSource sqlgDataSource;
-    private Logger logger = LoggerFactory.getLogger(SqlgGraph.class.getName());
+    private static Logger logger = LoggerFactory.getLogger(SqlgGraph.class);
     private final SqlgTransaction sqlgTransaction;
     private Topology topology;
     private GremlinParser gremlinParser;

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgProperty.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgProperty.java
@@ -23,7 +23,7 @@ import static org.umlg.sqlg.structure.topology.Topology.VERTEX_PREFIX;
  */
 public class SqlgProperty<V> implements Property<V>, Serializable {
 
-    private Logger logger = LoggerFactory.getLogger(SqlgProperty.class.getName());
+    private static Logger logger = LoggerFactory.getLogger(SqlgProperty.class);
     private final String key;
     private V value;
     private SqlgElement element;

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgStartupManager.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgStartupManager.java
@@ -29,7 +29,7 @@ import static org.umlg.sqlg.structure.topology.Topology.*;
  */
 class SqlgStartupManager {
 
-    private Logger logger = LoggerFactory.getLogger(SqlgStartupManager.class.getName());
+    private static Logger logger = LoggerFactory.getLogger(SqlgStartupManager.class);
     private SqlgGraph sqlgGraph;
     private SqlDialect sqlDialect;
 

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgTransaction.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgTransaction.java
@@ -29,7 +29,7 @@ public class SqlgTransaction extends AbstractThreadLocalTransaction {
     private BeforeCommit beforeCommitFunction;
     private AfterCommit afterCommitFunction;
     private AfterRollback afterRollbackFunction;
-    private Logger logger = LoggerFactory.getLogger(SqlgTransaction.class.getName());
+    private static Logger logger = LoggerFactory.getLogger(SqlgTransaction.class);
     private boolean cacheVertices = false;
 
     private final ThreadLocal<TransactionCache> threadLocalTx = ThreadLocal.withInitial(() -> null);

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgVertex.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgVertex.java
@@ -26,7 +26,7 @@ import static org.umlg.sqlg.structure.topology.Topology.*;
 public class SqlgVertex extends SqlgElement implements Vertex {
 
     public static final String WHERE = " WHERE ";
-    private Logger logger = LoggerFactory.getLogger(SqlgVertex.class.getName());
+    private static Logger logger = LoggerFactory.getLogger(SqlgVertex.class);
 
     /**
      * @param sqlgGraph       The graph.

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/ds/C3P0DataSource.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/ds/C3P0DataSource.java
@@ -15,7 +15,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class C3P0DataSource implements SqlgDataSourceFactory.SqlgDataSource {
 
-    private static Logger logger = LoggerFactory.getLogger(C3P0DataSource.class.getName());
+    private static Logger logger = LoggerFactory.getLogger(C3P0DataSource.class);
 
     private final ComboPooledDataSource dss;
     private final String jdbcUrl;

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/topology/AbstractLabel.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/topology/AbstractLabel.java
@@ -23,7 +23,7 @@ import static org.umlg.sqlg.structure.topology.Topology.*;
  */
 public abstract class AbstractLabel implements TopologyInf {
 
-    private Logger logger = LoggerFactory.getLogger(AbstractLabel.class.getName());
+    private static Logger logger = LoggerFactory.getLogger(AbstractLabel.class);
     protected boolean committed = true;
     protected String label;
     protected SqlgGraph sqlgGraph;

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/topology/EdgeLabel.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/topology/EdgeLabel.java
@@ -25,7 +25,7 @@ import static org.umlg.sqlg.structure.topology.Topology.*;
  */
 public class EdgeLabel extends AbstractLabel {
 
-    private Logger logger = LoggerFactory.getLogger(EdgeLabel.class.getName());
+    private static Logger logger = LoggerFactory.getLogger(EdgeLabel.class);
     //This just won't stick in my brain.
     //hand (out) ----<label>---- finger (in)
     Set<VertexLabel> outVertexLabels = new HashSet<>();

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/topology/Index.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/topology/Index.java
@@ -21,7 +21,7 @@ import static org.umlg.sqlg.structure.topology.Topology.VERTEX_PREFIX;
  */
 public class Index implements TopologyInf {
 
-    private Logger logger = LoggerFactory.getLogger(Index.class.getName());
+    private static Logger logger = LoggerFactory.getLogger(Index.class);
     private String name;
     private boolean committed = true;
     private AbstractLabel abstractLabel;

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/topology/Schema.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/topology/Schema.java
@@ -30,7 +30,7 @@ import static org.umlg.sqlg.structure.topology.Topology.*;
  */
 public class Schema implements TopologyInf {
 
-    private static Logger logger = LoggerFactory.getLogger(Schema.class.getName());
+    private static Logger logger = LoggerFactory.getLogger(Schema.class);
     private SqlgGraph sqlgGraph;
     private Topology topology;
     private String name;

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/topology/VertexLabel.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/topology/VertexLabel.java
@@ -27,7 +27,7 @@ import static org.umlg.sqlg.structure.topology.Topology.*;
  */
 public class VertexLabel extends AbstractLabel {
 
-    private Logger logger = LoggerFactory.getLogger(VertexLabel.class.getName());
+    private static Logger logger = LoggerFactory.getLogger(VertexLabel.class);
     private Schema schema;
 
     //hand (out) ----<label>---- finger (in)

--- a/sqlg-core/src/main/java/org/umlg/sqlg/util/SqlgUtil.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/util/SqlgUtil.java
@@ -44,7 +44,7 @@ import static org.umlg.sqlg.structure.topology.Topology.VERTEX_PREFIX;
  */
 public class SqlgUtil {
 
-    private static Logger logger = LoggerFactory.getLogger(SqlgUtil.class.getName());
+    private static Logger logger = LoggerFactory.getLogger(SqlgUtil.class);
 
     //This is the default count to indicate whether to use in statement or join onto a temp table.
     //As it happens postgres join to temp is always faster except for count = 1 when in is not used but '='


### PR DESCRIPTION
I don't know why loggers weren't static, since this means we create a new logger for each vertex, property, etc. So I made them all static, initialized with the class for brevity, only the dialect logger which uses the actual class I haven't touched. I have also a branch doing the same changes based on the 1.4.1 tag just in case.