### PR TITLE
Check for non existing properties inside andor

### DIFF
--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/filter/or/TestOrStep.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/filter/or/TestOrStep.java
@@ -64,6 +64,50 @@ public class TestOrStep extends BaseTest {
     }
     
     @Test
+    public void testOrMissingProperty() {
+        Vertex a1 = this.sqlgGraph.addVertex(T.label, "A", "name", "a1","p1","v1");
+        Vertex a2 = this.sqlgGraph.addVertex(T.label, "A", "name", "a2","p1","v1");
+        Vertex a3 = this.sqlgGraph.addVertex(T.label, "A", "name", "a3","p1","v1");
+        this.sqlgGraph.addVertex(T.label, "A", "name", "a4","p1","v1");
+        this.sqlgGraph.tx().commit();
+        DefaultGraphTraversal<Vertex, Vertex> traversal = (DefaultGraphTraversal<Vertex, Vertex>) this.sqlgGraph.traversal()
+                .V().hasLabel("A")
+                .or(
+                        __.has("name", "a1").has("p1","v1"),
+                        __.has("name", "a2"),
+                        __.has("name", "a3").has("p2","v2")
+                );
+        List<Vertex> vertices = traversal.toList();
+        Assert.assertEquals(1, traversal.getSteps().size());
+        Assert.assertEquals(2, vertices.size());
+        Assert.assertTrue(vertices.contains(a1) && vertices.contains(a2));
+        
+        traversal = (DefaultGraphTraversal<Vertex, Vertex>) this.sqlgGraph.traversal()
+                .V().hasLabel("A")
+                .or(
+                        __.has("name", "a1").has("p1","v1"),
+                        __.has("name", "a2"),
+                        __.has("name", "a3").has("p2")
+                );
+        vertices = traversal.toList();
+        //Assert.assertEquals(1, traversal.getSteps().size());
+        Assert.assertEquals(2, vertices.size());
+        Assert.assertTrue(vertices.contains(a1) && vertices.contains(a2));
+        
+        traversal = (DefaultGraphTraversal<Vertex, Vertex>) this.sqlgGraph.traversal()
+                .V().hasLabel("A")
+                .or(
+                        __.has("name", "a1").has("p1","v1"),
+                        __.has("name", "a2"),
+                        __.has("name", "a3").hasNot("p2")
+                );
+        vertices = traversal.toList();
+        //Assert.assertEquals(1, traversal.getSteps().size());
+        Assert.assertEquals(3, vertices.size());
+        Assert.assertTrue(vertices.contains(a1) && vertices.contains(a2) && vertices.contains(a3));
+    }
+    
+    @Test
     public void testOrStepOptimized() {
         Vertex a1 = this.sqlgGraph.addVertex(T.label, "A", "name", "a1");
         Vertex a2 = this.sqlgGraph.addVertex(T.label, "A", "name", "a2");


### PR DESCRIPTION
Using non existing property inside an or/and generates invalid SQL. Not sure if my fix is at the best place, but we probably don't want to have to evaluate if we're inside `and` or `or`, so letting the db calculate the boolean logic seems best.