### PR TITLE
Use fetch size

### DIFF
--- a/sqlg-core/src/main/java/org/umlg/sqlg/sql/dialect/SqlDialect.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/sql/dialect/SqlDialect.java
@@ -985,4 +985,12 @@ public interface SqlDialect {
     default boolean supportsTruncateMultipleTablesTogether() {
         return false;
     }
+    
+    /**
+     * get the default fetch size
+     * @return the default fetch size, maybe null if we want to use the default from the driver
+     */
+    default Integer getDefaultFetchSize(){
+    	return null;
+    }
 }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/strategy/SqlgSqlExecutor.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/strategy/SqlgSqlExecutor.java
@@ -134,7 +134,11 @@ public class SqlgSqlExecutor {
             sqlgGraph.tx().add(preparedStatement);
             int parameterCount = 1;
             SqlgUtil.setParametersOnStatement(sqlgGraph, distinctQueryStack, preparedStatement, parameterCount);
-//            preparedStatement.setFetchSize(100_000);
+            // https://jdbc.postgresql.org/documentation/head/query.html#query-with-cursor
+            // this is critical to use a cursor, otherwise we load everything into memory
+            if (sqlgGraph.tx().getFetchSize()!=null){
+            	 preparedStatement.setFetchSize(sqlgGraph.tx().getFetchSize());
+            }
             ResultSet resultSet = preparedStatement.executeQuery();
             ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
             return Triple.of(resultSet, resultSetMetaData, preparedStatement);

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgGraph.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgGraph.java
@@ -291,6 +291,9 @@ public class SqlgGraph implements Graph {
             throw new RuntimeException(e);
         }
         this.sqlgTransaction = new SqlgTransaction(this, this.configuration.getBoolean("cache.vertices", false));
+        // read fetch size from configuration, use default as specified in the dialect
+        this.sqlgTransaction.setFetchSize(this.configuration.getInteger("fetch.size", this.sqlDialect.getDefaultFetchSize()));
+        
         this.tx().readWrite();
         //Instantiating Topology will create the 'public' schema if it does not exist.
         this.topology = new Topology(this);

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgGraph.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgGraph.java
@@ -292,7 +292,7 @@ public class SqlgGraph implements Graph {
         }
         this.sqlgTransaction = new SqlgTransaction(this, this.configuration.getBoolean("cache.vertices", false));
         // read fetch size from configuration, use default as specified in the dialect
-        this.sqlgTransaction.setFetchSize(this.configuration.getInteger("fetch.size", this.sqlDialect.getDefaultFetchSize()));
+        this.sqlgTransaction.setDefaultFetchSize(this.configuration.getInteger("fetch.size", this.sqlDialect.getDefaultFetchSize()));
         
         this.tx().readWrite();
         //Instantiating Topology will create the 'public' schema if it does not exist.

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgTransaction.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgTransaction.java
@@ -36,7 +36,13 @@ public class SqlgTransaction extends AbstractThreadLocalTransaction {
 
     private final ThreadLocal<PreparedStatementCache> threadLocalPreparedStatementTx = ThreadLocal.withInitial(PreparedStatementCache::new);
 
-    SqlgTransaction(Graph sqlgGraph, boolean cacheVertices) {
+    /**
+     * default fetch size
+     */
+    private Integer fetchSize = null;
+
+
+	SqlgTransaction(Graph sqlgGraph, boolean cacheVertices) {
         super(sqlgGraph);
         this.sqlgGraph = (SqlgGraph) sqlgGraph;
         this.cacheVertices = cacheVertices;
@@ -303,4 +309,13 @@ public class SqlgTransaction extends AbstractThreadLocalTransaction {
     	readWrite();
     	this.threadLocalTx.get().setLazyQueries(lazy);
     }
+    
+    
+    public Integer getFetchSize() {
+		return fetchSize;
+	}
+
+	public void setFetchSize(Integer fetchSize) {
+		this.fetchSize = fetchSize;
+	}
 }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/TransactionCache.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/TransactionCache.java
@@ -23,6 +23,11 @@ class TransactionCache {
      */
     private boolean lazyQueries;
 
+    /**
+     * default fetch size
+     */
+    private Integer fetchSize = null;
+    
 
 	static TransactionCache of(boolean cacheVertices, Connection connection, BatchManager batchManager,boolean lazyQueries) {
         return new TransactionCache(cacheVertices, connection, batchManager,lazyQueries);
@@ -149,6 +154,14 @@ class TransactionCache {
      */
 	public void setLazyQueries(boolean lazyQueries) {
 		this.lazyQueries = lazyQueries;
+	}
+
+	public Integer getFetchSize() {
+		return fetchSize;
+	}
+
+	public void setFetchSize(Integer fetchSize) {
+		this.fetchSize = fetchSize;
 	}
 
 }

--- a/sqlg-postgres-parent/sqlg-postgres-dialect/src/main/java/org/umlg/sqlg/sql/dialect/PostgresDialect.java
+++ b/sqlg-postgres-parent/sqlg-postgres-dialect/src/main/java/org/umlg/sqlg/sql/dialect/PostgresDialect.java
@@ -3846,4 +3846,13 @@ public class PostgresDialect extends BaseSqlDialect implements SqlBulkDialect {
     public boolean supportsTruncateMultipleTablesTogether() {
         return true;
     }
+    
+    /**
+     * https://jdbc.postgresql.org/documentation/head/query.html#query-with-cursor
+     * this is critical to use a cursor, otherwise we load everything into memory
+     */
+    @Override
+    public Integer getDefaultFetchSize() {
+    	return 1_000;
+    };
 }


### PR DESCRIPTION
We ran into a big issue: we have a query that returns millions of items, we thought it may be slow but we need to process all these items. But the memory explodes. It turns out that PostgreSQL JDBC driver by default retrieves the full results in memory. This is of course not acceptable in our use-case.
So this PR set the fetch size on statements. Setting it to a positive integer for Postgres moves it to cursor-mode. By default the fetch size is not set, except for Postgres. It is overridable per graph via configuration.