### PR TITLE
Remove default fetch size for Postgres as it slows down the test suite

### DIFF
--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgGraph.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgGraph.java
@@ -291,7 +291,11 @@ public class SqlgGraph implements Graph {
             throw new RuntimeException(e);
         }
         this.sqlgTransaction = new SqlgTransaction(this, this.configuration.getBoolean("cache.vertices", false));
+        
         // read fetch size from configuration, use default as specified in the dialect
+        // this can be very useful for Postgres since according to < https://jdbc.postgresql.org/documentation/head/query.html#query-with-cursor>
+        // Postgres JDBC will load the whole result in memory
+        // so if there are massive queries, setting the fetch size will avoid out of memory errors
         this.sqlgTransaction.setDefaultFetchSize(this.configuration.getInteger("fetch.size", this.sqlDialect.getDefaultFetchSize()));
         
         this.tx().readWrite();

--- a/sqlg-postgres-parent/sqlg-postgres-dialect/src/main/java/org/umlg/sqlg/sql/dialect/PostgresDialect.java
+++ b/sqlg-postgres-parent/sqlg-postgres-dialect/src/main/java/org/umlg/sqlg/sql/dialect/PostgresDialect.java
@@ -3847,12 +3847,4 @@ public class PostgresDialect extends BaseSqlDialect implements SqlBulkDialect {
         return true;
     }
     
-    /**
-     * https://jdbc.postgresql.org/documentation/head/query.html#query-with-cursor
-     * this is critical to use a cursor, otherwise we load everything into memory
-     */
-    @Override
-    public Integer getDefaultFetchSize() {
-    	return 1_000;
-    };
 }


### PR DESCRIPTION
As discussed.