### PR TITLE
bump jdbc driver version

### DIFF
--- a/sqlg-postgres-parent/sqlg-postgres-dialect/pom.xml
+++ b/sqlg-postgres-parent/sqlg-postgres-dialect/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.1.4.jre7</version>
+            <version>42.2.2</version>
         </dependency>
         <dependency>
             <groupId>net.postgis</groupId>


### PR DESCRIPTION
During testing we ran into postgresql issues that have the same symptoms as https://github.com/pgjdbc/pgjdbc/issues/811. This should be fixed in the last version of the driver, so I've bumped the version. Not sure why we were using the JRE-7 version since we're java 8 only anyway.