### PR TITLE
Remove closed statements from cache

### DIFF
--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/PreparedStatementCache.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/PreparedStatementCache.java
@@ -2,24 +2,28 @@ package org.umlg.sqlg.structure;
 
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.IdentityHashMap;
+import java.util.Map;
 
 /**
+ * Cache all statements to close them when iteration is done
  * Date: 2016/05/15
  * Time: 2:24 PM
  */
-@SuppressWarnings("ALL")
 public class PreparedStatementCache {
 
-    private List<PreparedStatement> cache = new ArrayList<>();
+    private Map<PreparedStatement,Boolean> cache = new IdentityHashMap<>();
 
     void add(PreparedStatement preparedStatement) {
-        this.cache.add(preparedStatement);
+        this.cache.put(preparedStatement,Boolean.TRUE);
     }
-
+    
+    void remove(PreparedStatement preparedStatement) {
+        this.cache.remove(preparedStatement);
+    }
+    
     public void close() throws SQLException {
-        for (PreparedStatement preparedStatement : this.cache) {
+        for (PreparedStatement preparedStatement : this.cache.keySet()) {
             preparedStatement.close();
         }
         this.cache.clear();
@@ -27,5 +31,9 @@ public class PreparedStatementCache {
 
     public boolean isEmpty() {
         return this.cache.isEmpty();
+    }
+    
+    public int size() {
+    	return this.cache.size();
     }
 }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgCompiledResultIterator.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgCompiledResultIterator.java
@@ -349,6 +349,7 @@ public class SqlgCompiledResultIterator<E> implements Iterator<E> {
         if (this.queryResult != null) {
             try {
                 this.queryResult.getRight().close();
+                this.sqlgGraph.tx().getPreparedStatementCache().remove(this.queryResult.getRight());
                 this.queryResult = null;
             } catch (SQLException e) {
                 throw new RuntimeException(e);

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/preparedStatement/TestClosingPreparedStatement.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/preparedStatement/TestClosingPreparedStatement.java
@@ -1,7 +1,14 @@
 package org.umlg.sqlg.test.preparedStatement;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.apache.commons.lang3.time.StopWatch;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Test;
 import org.umlg.sqlg.test.BaseTest;
 
@@ -25,10 +32,10 @@ public class TestClosingPreparedStatement extends BaseTest {
 //    }
 
     @Test
-    public void test() {
+    public void testAddCommit() {
         StopWatch stopWatch = new StopWatch();
         stopWatch.start();
-        for (int i = 0; i < 1_000_000; i++) {
+        for (int i = 0; i < 100_000; i++) {
             this.sqlgGraph.addVertex(T.label, "A");
             if (i % 10_000 == 0) {
                 System.out.println(i);
@@ -36,10 +43,35 @@ public class TestClosingPreparedStatement extends BaseTest {
             }
             if (i % 1000 == 0) {
                 this.sqlgGraph.tx().commit();
+                assertTrue(this.sqlgGraph.tx().getPreparedStatementCache().isEmpty());
             }
         }
         this.sqlgGraph.tx().commit();
         stopWatch.stop();
         System.out.println(stopWatch.toString());
+    }
+    
+    @Test
+    public void testRead() {
+    	 Vertex v=this.sqlgGraph.addVertex(T.label, "A");
+    	 this.sqlgGraph.tx().commit();
+	     GraphTraversal<Vertex, Vertex> gt = sqlgGraph.traversal().V(v.id());
+         try {
+        	 Vertex v2= gt.next();
+        	 assertEquals(v.id(),v2.id());
+        	 assertFalse(this.sqlgGraph.tx().getPreparedStatementCache().isEmpty());
+        	 assertFalse(gt.hasNext());
+        	 assertTrue(this.sqlgGraph.tx().getPreparedStatementCache().isEmpty());
+         } finally {
+               try {
+                     gt.close(); 
+                     gt = null;
+               } catch (Exception e) {
+            	   e.printStackTrace();
+            	   fail(e.getMessage());
+               }
+         }
+
+    	 
     }
 }


### PR DESCRIPTION
The statement cache is never emptied until we commit or rollback, which exhausts memory pretty quickly. We remove a statement when we close it to improve on that.