### PR TITLE
Add a Docker image for Postgres

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 dist: trusty
 sudo: required
+services:
+  - docker
 before_install:
-  - sudo sed -i -e 's/max_connections.*/max_connections = 1000/' /etc/postgresql/9.6/main/postgresql.conf
-  - sudo sed -i -e 's/#max_locks_per_transaction.*/max_locks_per_transaction = 256/' /etc/postgresql/9.6/main/postgresql.conf
-  - sudo sed -i -e 's/#shared_buffers.*/shared_buffers = 1024MB/' /etc/postgresql/9.6/main/postgresql.conf
-  - sudo /etc/init.d/postgresql restart
+  - sudo /etc/init.d/postgresql stop
+  - docker run -d -p 5432:5432 --name sqlg-testdb-postgres $(docker build -q sqlg-testdb-postgres/)
 language: java
 jdk:
   - oraclejdk8
@@ -15,20 +15,6 @@ script:
   - sudo rm /etc/mavenrc
   - export MAVEN_OPTS="-Djava.security.egd=file:/dev/./urandom -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xmx5012m"
   - mvn -e -T40 test
-addons:
-  postgresql: "9.6"
-before_script:
-  - psql -c 'create database "sqlgraphdb";' -U postgres
-  - psql -c 'create database "g1";' -U postgres
-  - psql -c 'create database "g2";' -U postgres
-  - psql -c 'create database "prototype";' -U postgres
-  - psql -c 'create database "readGraph";' -U postgres
-  - psql -c 'create database "standard";' -U postgres
-  - psql -c 'create database "subgraph";' -U postgres
-  - psql -c 'create database "temp";' -U postgres
-  - psql -c 'create database "temp1";' -U postgres
-  - psql -c 'create database "temp2";' -U postgres
-  - psql -c 'create database "target";' -U postgres
 
 notifications:
   email:

--- a/sqlg-testdb-postgres/Dockerfile
+++ b/sqlg-testdb-postgres/Dockerfile
@@ -1,0 +1,4 @@
+FROM postgres:9.6-alpine
+
+COPY sqlg-setup.sql docker-entrypoint-initdb.d/
+

--- a/sqlg-testdb-postgres/sqlg-setup.sql
+++ b/sqlg-testdb-postgres/sqlg-setup.sql
@@ -1,0 +1,15 @@
+ALTER SYSTEM SET max_connections TO '1000';
+ALTER SYSTEM SET max_locks_per_transaction TO '256';
+ALTER SYSTEM SET shared_buffers TO '1024MB';
+
+CREATE DATABASE "sqlgraphdb";
+CREATE DATABASE "g1";
+CREATE DATABASE "g2";
+CREATE DATABASE "prototype";
+CREATE DATABASE "readGraph";
+CREATE DATABASE "standard";
+CREATE DATABASE "subgraph";
+CREATE DATABASE "temp";
+CREATE DATABASE "temp1";
+CREATE DATABASE "temp2";
+CREATE DATABASE "target";


### PR DESCRIPTION
Instead of using the Postgres available in Travis, this PR switches to a Docker image of Postgres that anyone can build and use for testing. The approach can be applied to other database implementations if desired (at which point it might be nice to add Docker Compose configuration for testing).

If you have Docker installed, you can simply the run the same `before_install` command that Travis runs to start up a Docker container running Postgres with the configuration changes and databases previously made in the Travis build.

When I ran the tests locally I did see a number of "The connection attempt failed." / "Connection reset" / "Connection reset by peer (connect failed)" errors. I don't know if that normally occurs or it was related to the use of Postgres in Docker (alternately, Postgres on Alpine). The `TestBulkWithin.testBulkWithinLocalTime` test also failed ("expected:<3> but was:<0>" on `TestBulkWithin.java:451`), again not sure if that was related or not.