### PR TITLE
improve error handling in flush in BatchManager

### DIFF
--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/BatchManager.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/BatchManager.java
@@ -188,21 +188,27 @@ public class BatchManager {
     }
 
     public void flush() {
-        this.isBusyFlushing = true;
-        this.sqlDialect.flushVertexCache(this.sqlgGraph, this.vertexCache);
-        this.sqlDialect.flushEdgeCache(this.sqlgGraph, this.edgeCache);
-        this.sqlDialect.flushVertexPropertyCache(this.sqlgGraph, this.vertexPropertyCache);
-        this.sqlDialect.flushEdgePropertyCache(this.sqlgGraph, this.edgePropertyCache);
-        this.sqlDialect.flushRemovedEdges(this.sqlgGraph, this.removeEdgeCache);
-        this.sqlDialect.flushRemovedVertices(this.sqlgGraph, this.removeVertexCache);
-        this.close();
-        this.isBusyFlushing = false;
-        this.sqlDialect.flushVertexGlobalUniqueIndexes(this.sqlgGraph, this.vertexCache);
-        this.sqlDialect.flushEdgeGlobalUniqueIndexes(this.sqlgGraph, this.edgeCache);
-        this.sqlDialect.flushVertexGlobalUniqueIndexPropertyCache(this.sqlgGraph, this.vertexPropertyCache);
-        this.sqlDialect.flushEdgeGlobalUniqueIndexPropertyCache(this.sqlgGraph, this.edgePropertyCache);
-        this.sqlDialect.flushRemovedGlobalUniqueIndexVertices(this.sqlgGraph, this.removeVertexCache);
-        this.clear();
+    	try {
+    		try {
+    			this.isBusyFlushing = true;
+    			this.sqlDialect.flushVertexCache(this.sqlgGraph, this.vertexCache);
+    			this.sqlDialect.flushEdgeCache(this.sqlgGraph, this.edgeCache);
+    			this.sqlDialect.flushVertexPropertyCache(this.sqlgGraph, this.vertexPropertyCache);
+    			this.sqlDialect.flushEdgePropertyCache(this.sqlgGraph, this.edgePropertyCache);
+    			this.sqlDialect.flushRemovedEdges(this.sqlgGraph, this.removeEdgeCache);
+    			this.sqlDialect.flushRemovedVertices(this.sqlgGraph, this.removeVertexCache);
+    		} finally {
+    			this.close();
+    			this.isBusyFlushing = false;
+    		}
+    		this.sqlDialect.flushVertexGlobalUniqueIndexes(this.sqlgGraph, this.vertexCache);
+    		this.sqlDialect.flushEdgeGlobalUniqueIndexes(this.sqlgGraph, this.edgeCache);
+    		this.sqlDialect.flushVertexGlobalUniqueIndexPropertyCache(this.sqlgGraph, this.vertexPropertyCache);
+    		this.sqlDialect.flushEdgeGlobalUniqueIndexPropertyCache(this.sqlgGraph, this.edgePropertyCache);
+    		this.sqlDialect.flushRemovedGlobalUniqueIndexVertices(this.sqlgGraph, this.removeVertexCache);
+    	} finally {
+    		this.clear();
+    	}
     }
 
     public void close() {


### PR DESCRIPTION
use finally in flush to reset isBusyFlushing and call close and clear to be able to continue with rollback and new transaction after exception inside flush.

We ran into the following problem: When 2 parallel batch imports try to create the same vertex, we get an error based on a unique constraint. This occurs inside the g.tx().flush(). Now we want to handle this situation by repeating the operations of the last transaction (now finding and updating or using instead of creating the specific vertex).

Unfortunately, this did not work, because the caches are not cleared and isBusyFlushing is never reset to false. Hopefully this change solves the problem (it seems to fix it for us).