### PR TITLE
Fix Text.endsWith and Text.nendsWith inline implementation

### DIFF
--- a/sqlg-core/src/main/java/org/umlg/sqlg/predicate/Text.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/predicate/Text.java
@@ -74,7 +74,7 @@ public enum Text implements BiPredicate<String, String> {
     }, endsWith{
         @Override
         public boolean test(final String first, final String second) {
-            return first.startsWith(second);
+            return first.endsWith(second);
         }
 
         @Override
@@ -84,7 +84,7 @@ public enum Text implements BiPredicate<String, String> {
     }, nendsWith{
         @Override
         public boolean test(final String first, final String second) {
-            return !first.startsWith(second);
+            return !first.endsWith(second);
         }
 
         @Override


### PR DESCRIPTION
Fix #314 by actually calling `endsWith` in `Text.endsWith` 