### PR TITLE
Log's timestamp does not match in Java 11 (Zulu JDK) #317

### DIFF
--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/topology/Topology.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/topology/Topology.java
@@ -20,6 +20,7 @@ import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -1381,7 +1382,8 @@ public class Topology {
                         .toList();
                 Preconditions.checkState(logs.size() == 1, "There must be one and only be one log, found %d", logs.size());
                 LocalDateTime timestamp = logs.get(0).value("timestamp");
-                Preconditions.checkState(timestamp.equals(notifyTimestamp), "notify log's timestamp does not match.");
+                Preconditions.checkState(Duration.between(notifyTimestamp, timestamp).toNanos() < 1000,
+						"notify log's timestamp does not match.");
                 int backEndPid = logs.get(0).value("pid");
                 Preconditions.checkState(backEndPid == pid, "notify pids do not match.");
                 ObjectNode log = logs.get(0).value("log");


### PR DESCRIPTION
calculated two timestamp difference and fail if it's over a threshold 1000 nanoseconds.