### PR TITLE
Allow customization of the data source implementation

### DIFF
--- a/sqlg-core/src/main/java/org/umlg/sqlg/SqlgPlugin.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/SqlgPlugin.java
@@ -48,12 +48,12 @@ public interface SqlgPlugin {
      * @throws IllegalStateException if no suitable Sqlg plugin could be found
      */
     public static SqlgPlugin load(String connectionUrl) {
-    	for (SqlgPlugin p : ServiceLoader.load(SqlgPlugin.class, SqlgPlugin.class.getClassLoader())) {
+        for (SqlgPlugin p : ServiceLoader.load(SqlgPlugin.class, SqlgPlugin.class.getClassLoader())) {
             if (p.getDriverFor(connectionUrl) != null) {
                 return p;
             }
         }
-    	throw new IllegalStateException("Could not find suitable Sqlg plugin for the JDBC URL: " + connectionUrl);
+        throw new IllegalStateException("Could not find suitable Sqlg plugin for the JDBC URL: " + connectionUrl);
     }
     
     /**
@@ -64,11 +64,11 @@ public interface SqlgPlugin {
      * @throws IllegalStateException if no suitable Sqlg plugin could be found
      */
     public static SqlgPlugin load(DatabaseMetaData metaData) throws SQLException {
-    	for (SqlgPlugin p : ServiceLoader.load(SqlgPlugin.class, SqlgPlugin.class.getClassLoader())) {
+        for (SqlgPlugin p : ServiceLoader.load(SqlgPlugin.class, SqlgPlugin.class.getClassLoader())) {
             if (p.canWorkWith(metaData)) {
                 return p;
             }
         }
-    	throw new IllegalStateException("Could not find suitable Sqlg plugin for the database: " + metaData.getDatabaseProductName());
+        throw new IllegalStateException("Could not find suitable Sqlg plugin for the database: " + metaData.getDatabaseProductName());
     }
 }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/SqlgPlugin.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/SqlgPlugin.java
@@ -4,6 +4,7 @@ import org.umlg.sqlg.sql.dialect.SqlDialect;
 
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
+import java.util.ServiceLoader;
 
 /**
  * @author Lukas Krejci
@@ -38,4 +39,36 @@ public interface SqlgPlugin {
      * @return the dialect to use, never null
      */
     SqlDialect instantiateDialect();
+    
+    /**
+     * Loads the plugin to use for the provided JDBC URL.
+     * 
+     * @param connectionUrl the JDBC URL of the database to connect to
+     * @return the plugin to use, never null
+     * @throws IllegalStateException if no suitable Sqlg plugin could be found
+     */
+    public static SqlgPlugin load(String connectionUrl) {
+    	for (SqlgPlugin p : ServiceLoader.load(SqlgPlugin.class, SqlgPlugin.class.getClassLoader())) {
+            if (p.getDriverFor(connectionUrl) != null) {
+                return p;
+            }
+        }
+    	throw new IllegalStateException("Could not find suitable Sqlg plugin for the JDBC URL: " + connectionUrl);
+    }
+    
+    /**
+     * Loads the plugin to use for the provided database meta data.
+     * 
+     * @param metaData the JDBC meta data from an established database connection
+     * @return the plugin to use, never null
+     * @throws IllegalStateException if no suitable Sqlg plugin could be found
+     */
+    public static SqlgPlugin load(DatabaseMetaData metaData) throws SQLException {
+    	for (SqlgPlugin p : ServiceLoader.load(SqlgPlugin.class, SqlgPlugin.class.getClassLoader())) {
+            if (p.canWorkWith(metaData)) {
+                return p;
+            }
+        }
+    	throw new IllegalStateException("Could not find suitable Sqlg plugin for the database: " + metaData.getDatabaseProductName());
+    }
 }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgDataSourceFactory.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgDataSourceFactory.java
@@ -2,20 +2,56 @@ package org.umlg.sqlg.structure;
 
 import static org.umlg.sqlg.structure.SqlgGraph.JDBC_URL;
 
+import java.lang.reflect.InvocationTargetException;
+
 import org.apache.commons.configuration.Configuration;
+import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.umlg.sqlg.structure.ds.C3P0DataSource;
 import org.umlg.sqlg.structure.ds.JNDIDataSource;
 
 /**
  * Created by petercipov on 27/02/2017.
  */
-public class SqlgDataSourceFactory {
-    public static SqlgDataSource create(final Configuration configuration) throws Exception {
-        final String jdbcUrl = configuration.getString(JDBC_URL);
-        if (JNDIDataSource.isJNDIUrl(jdbcUrl)) {
-            return JNDIDataSource.create(configuration);
-        } else {
-            return C3P0DataSource.create(configuration);
+class SqlgDataSourceFactory {
+    public static SqlgDataSource create(final Configuration configuration) {
+        if (null == configuration)
+            throw Graph.Exceptions.argumentCanNotBeNull("configuration");
+        
+        try {
+            
+            final String clazz = configuration.getString(SqlgGraph.DATA_SOURCE, null);
+            if (null == clazz) {
+                final String jdbcUrl = configuration.getString(JDBC_URL, "");
+                if (JNDIDataSource.isJNDIUrl(jdbcUrl)) {
+                    return JNDIDataSource.create(configuration);
+                } else {
+                    return C3P0DataSource.create(configuration);
+                }
+            }
+            
+            final Class<?> dataSourceClass;
+            try {
+                dataSourceClass = Class.forName(clazz);
+            } catch (final ClassNotFoundException e) {
+                throw new RuntimeException(String.format("SqlgDataSourceFactory could not find [%s] - Ensure that the jar is in the classpath", clazz));
+            }
+
+            final SqlgDataSource dataSource;
+            try {
+                // will use create(Configuration c) to instantiate
+                dataSource = (SqlgDataSource) dataSourceClass.getMethod("create", Configuration.class).invoke(null, configuration);
+            } catch (final NoSuchMethodException e1) {
+                throw new RuntimeException(String.format("SqlgDataSourceFactory can only instantiate SqlgDataSource implementations from classes that have a static create() method that takes a single Apache Commons Configuration argument - [%s] does not seem to have one", dataSourceClass.getName()));
+            } catch (InvocationTargetException e2) {
+                throw new RuntimeException(String.format("SqlgDataSourceFactory could not create this SqlgDataSource implementation [%s]", dataSourceClass.getName()), e2);
+            } catch (final Exception e3) {
+                throw new RuntimeException(String.format("SqlgDataSourceFactory could not instantiate this SqlgDataSource implementation [%s]", dataSourceClass.getName()), e3);
+            }
+            return dataSource;
+            
+        } catch (Exception ex) {
+            // Exception handling preserves an existing behavior
+            throw new IllegalStateException("Could not create sqlg data source.", ex);
         }
     }
 }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgDataSourceFactory.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgDataSourceFactory.java
@@ -12,7 +12,7 @@ import org.umlg.sqlg.structure.ds.JNDIDataSource;
 /**
  * Created by petercipov on 27/02/2017.
  */
-class SqlgDataSourceFactory {
+public class SqlgDataSourceFactory {
     public static SqlgDataSource create(final Configuration configuration) {
         if (null == configuration)
             throw Graph.Exceptions.argumentCanNotBeNull("configuration");

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgGraph.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgGraph.java
@@ -22,7 +22,6 @@ import org.apache.tinkerpop.gremlin.structure.util.FeatureDescriptor;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.umlg.sqlg.SqlgPlugin;
 import org.umlg.sqlg.sql.dialect.SqlBulkDialect;
 import org.umlg.sqlg.sql.dialect.SqlDialect;
 import org.umlg.sqlg.sql.parse.GremlinParser;

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/ds/JNDIDataSource.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/ds/JNDIDataSource.java
@@ -1,13 +1,9 @@
 package org.umlg.sqlg.structure.ds;
 
 import java.sql.Connection;
-import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
-import java.util.ServiceLoader;
 
 import org.apache.commons.configuration.Configuration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.umlg.sqlg.SqlgPlugin;
 import org.umlg.sqlg.sql.dialect.SqlDialect;
 import org.umlg.sqlg.structure.SqlgDataSource;
@@ -20,9 +16,8 @@ import javax.sql.DataSource;
 /**
  * Created by petercipov on 27/02/2017.
  */
-public class JNDIDataSource implements SqlgDataSource {
+public final class JNDIDataSource implements SqlgDataSource {
 
-    private static final Logger logger = LoggerFactory.getLogger(JNDIDataSource.class);
     private static final String JNDI_PREFIX = "jndi:";
 
     private final DataSource dataSource;
@@ -46,28 +41,10 @@ public class JNDIDataSource implements SqlgDataSource {
 
         SqlDialect sqlDialect;
         try (Connection conn = ds.getConnection()) {
-            SqlgPlugin p = findSqlgPlugin(conn.getMetaData());
-            if (p == null) {
-                throw new IllegalStateException("Could not find suitable sqlg plugin for the JDBC URL: " + url);
-            }
-
-            sqlDialect = p.instantiateDialect();
+        	sqlDialect = SqlgPlugin.load(conn.getMetaData()).instantiateDialect();
         }
 
         return new JNDIDataSource(url, ds, sqlDialect);
-    }
-
-    private static SqlgPlugin findSqlgPlugin(DatabaseMetaData metadata) throws SQLException {
-        for (SqlgPlugin p : ServiceLoader.load(SqlgPlugin.class, JNDIDataSource.class.getClassLoader())) {
-            logger.info("found plugin for SqlgPlugin.class");
-            if (p.canWorkWith(metadata)) {
-                return p;
-            } else {
-                logger.info("can not work with SqlgPlugin.class");
-            }
-        }
-
-        return null;
     }
 
     private JNDIDataSource(String jdbcUrl, DataSource dataSource, SqlDialect sqlDialect) {

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/ds/JNDIDataSource.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/ds/JNDIDataSource.java
@@ -41,7 +41,7 @@ public final class JNDIDataSource implements SqlgDataSource {
 
         SqlDialect sqlDialect;
         try (Connection conn = ds.getConnection()) {
-        	sqlDialect = SqlgPlugin.load(conn.getMetaData()).instantiateDialect();
+            sqlDialect = SqlgPlugin.load(conn.getMetaData()).instantiateDialect();
         }
 
         return new JNDIDataSource(url, ds, sqlDialect);

--- a/sqlg-test/src/main/java/org/umlg/sqlg/AllTest.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/AllTest.java
@@ -10,6 +10,7 @@ import org.umlg.sqlg.test.batch.*;
 import org.umlg.sqlg.test.branchstep.TestSqlgBranchStep;
 import org.umlg.sqlg.test.complex.TestComplex;
 import org.umlg.sqlg.test.complex.TestGithub;
+import org.umlg.sqlg.test.datasource.TestCustomDataSource;
 import org.umlg.sqlg.test.datasource.TestDataSource;
 import org.umlg.sqlg.test.datasource.TestJNDIInitialization;
 import org.umlg.sqlg.test.edgehas.TestEdgeHas;
@@ -262,7 +263,8 @@ import org.umlg.sqlg.test.where.TestTraversalFilterStepBarrier;
         TestVarChar.class,
         TestTopologySchemaDeleteMultipleGraphs.class,
         TestTraversalAddV.class,
-        TestDataSource.class
+        TestDataSource.class,
+        TestCustomDataSource.class,
 })
 public class AllTest {
 

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/datasource/TestCustomDataSource.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/datasource/TestCustomDataSource.java
@@ -1,0 +1,79 @@
+package org.umlg.sqlg.test.datasource;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+import java.net.URL;
+import java.util.Objects;
+
+import javax.sql.DataSource;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.junit.Before;
+import org.junit.Test;
+import org.umlg.sqlg.sql.dialect.SqlDialect;
+import org.umlg.sqlg.structure.SqlgDataSource;
+import org.umlg.sqlg.structure.SqlgGraph;
+import org.umlg.sqlg.structure.ds.C3P0DataSource;
+
+/**
+ * @author jgustie
+ */
+public class TestCustomDataSource {
+
+    protected Configuration configuration;
+
+    @Before
+    public void before() throws ConfigurationException {
+        URL sqlProperties = Thread.currentThread().getContextClassLoader().getResource("sqlg.properties");
+        this.configuration = new PropertiesConfiguration(sqlProperties);
+    }
+
+    @Test
+    public void testCustomDataSourceImplementation() {
+        configuration.setProperty(SqlgGraph.DATA_SOURCE, TestSqlgDataSource.class.getName());
+        try (SqlgGraph sqlgGraph = SqlgGraph.open(this.configuration)) {
+            assertThat(sqlgGraph.getSqlgDataSource(), instanceOf(TestSqlgDataSource.class));
+        }
+    }
+
+    /**
+     * Sqlg data source implementation to use for testing.
+     */
+    public static class TestSqlgDataSource implements SqlgDataSource {
+
+        public static TestSqlgDataSource create(Configuration configuration) throws Exception {
+            // We cannot extend C3P0DataSoruce, but we can delegate everything to it
+            return new TestSqlgDataSource(C3P0DataSource.create(configuration));
+        }
+
+        private final SqlgDataSource delegate;
+
+        private TestSqlgDataSource(SqlgDataSource delegate) {
+            this.delegate = Objects.requireNonNull(delegate);
+        }
+
+        public DataSource getDatasource() {
+            return delegate.getDatasource();
+        }
+
+        public SqlDialect getDialect() {
+            return delegate.getDialect();
+        }
+
+        public void close() {
+            delegate.close();
+        }
+
+        public void softResetPool() {
+            delegate.softResetPool();
+        }
+
+        public String getPoolStatsAsJson() {
+            return delegate.getPoolStatsAsJson();
+        }
+    }
+    
+}

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/tp3/SqlgAbstractGraphProvider.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/tp3/SqlgAbstractGraphProvider.java
@@ -13,7 +13,6 @@ import org.umlg.sqlg.structure.*;
 import org.umlg.sqlg.structure.topology.Topology;
 import org.umlg.sqlg.util.SqlgUtil;
 
-import java.beans.PropertyVetoException;
 import java.sql.Connection;
 import java.util.HashSet;
 import java.util.Set;
@@ -53,8 +52,6 @@ public abstract class SqlgAbstractGraphProvider extends AbstractGraphProvider {
             try (Connection conn = sqlgDataSource.getDatasource().getConnection()) {
                 SqlgUtil.dropDb(sqlDialect, conn);
             }
-        } catch (PropertyVetoException e) {
-            throw new RuntimeException(e);
         } finally {
             if (sqlgDataSource != null) {
                 sqlgDataSource.close();


### PR DESCRIPTION
In the process of upgrading to 2.x I noticed that the `SqlgGraph.open` method that accepted a customized data source was made `private` in acbd03e6faad3a8f6bf8f8000d4f94fd0bffad99, making it impossible to use custom implementations of `SqlgDataSource` (in my case, a Tomcat JDBC backed connection pool not registered with JNDI).

This PR improves `SqlgDataSourceFactory` by borrowing heavily from the TinkerPop `GraphFactory` class to allow customization of the `SqlgDataSource` implementation via configuration properties. This ensures only the single argument `SqlgGraph.open` methods are public while still allowing customization (hopefully this is now more clear).

I gave the property used to configure the data source a "sqlg." prefix (this is consistent with `Graph.GRAPH` which uses the "gremlin." prefix); I have found `Configuration.subset` to be very useful for isolating configuration parameters when they are namespaced like this.

It does not appear that the JDBC URL configuration property is still required by `SqlgGraph`, it may be worth removing that restriction in a future version (it is required by both the JNDI and C3P0 Sqlg data sources, but I was careful not to introduce the requirement to the `SqlgDataSourceFactory`).