### PR TITLE
Upgrades Tinkerpop to 3.4.1 and SLF4J to 1.7.25, adds Travis/docker-compose scripting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ jdk:
 script:
   - cd $TRAVIS_BUILD_DIR
   - sudo rm /etc/mavenrc
-  - export MAVEN_OPTS="-Djava.security.egd=file:/dev/./urandom -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xmx5012m"
-  - mvn -e -T40 test
+  - export MAVEN_OPTS="-Djava.security.egd=file:/dev/urandom -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xmx5012m"
+  - mvn test
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ script:
   - cd $TRAVIS_BUILD_DIR
   - sudo rm /etc/mavenrc
   - export MAVEN_OPTS="-Djava.security.egd=file:/dev/urandom -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xmx5012m"
-  - mvn test
+  - mvn -T4 test
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,23 @@
-dist: trusty
 sudo: required
+
 services:
   - docker
+
 before_install:
+  # Stops the local instance of Postgres.
   - sudo /etc/init.d/postgresql stop
-  - docker run -d -p 5432:5432 --name sqlg-testdb-postgres $(docker build -q sqlg-testdb-postgres/)
+  
+  # Checks which Docker containers are running for debug purposes.
+  - docker ps
+
+  # Starts the test Postgres server within a Docker container.
+  - cd sqlg-testdb-postgres && ./start.sh
+
 language: java
+
 jdk:
   - oraclejdk8
-#env:
-#    - MAVEN_OPTS="-Xmx4096m"
-#script: "./run-tests.sh"
+
 script:
   - sudo rm /etc/mavenrc
   - export MAVEN_OPTS="-Djava.security.egd=file:/dev/./urandom -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xmx5012m"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,16 @@ before_install:
   # Starts the test Postgres server within a Docker container.
   - cd sqlg-testdb-postgres && ./start.sh
 
+  # Sleeps 30 seconds to allow Postgres database to start.
+  - sleep 30
+
 language: java
 
 jdk:
   - oraclejdk8
 
 script:
+  - cd $TRAVIS_BUILD_DIR
   - sudo rm /etc/mavenrc
   - export MAVEN_OPTS="-Djava.security.egd=file:/dev/./urandom -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xmx5012m"
   - mvn -e -T40 test

--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,8 @@
     </scm>
     <properties>
         <sqlg.version>2.0.2-SNAPSHOT</sqlg.version>
-        <tinkerpop.version>3.3.5</tinkerpop.version>
-        <slf4j.version>1.7.21</slf4j.version>
+        <tinkerpop.version>3.4.1</tinkerpop.version>
+        <slf4j.version>1.7.25</slf4j.version>
         <junit.version>4.12</junit.version>
     </properties>
     <developers>

--- a/sqlg-core/src/main/java/org/umlg/sqlg/step/SqlgAddVertexStartStep.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/step/SqlgAddVertexStartStep.java
@@ -2,6 +2,7 @@ package org.umlg.sqlg.step;
 
 import org.apache.tinkerpop.gremlin.process.traversal.*;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Mutating;
+import org.apache.tinkerpop.gremlin.process.traversal.step.Parameterizing;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Scoping;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.Parameters;
@@ -24,13 +25,18 @@ import java.util.Set;
  */
 public class SqlgAddVertexStartStep extends SqlgAbstractStep<Vertex, Vertex> implements Mutating<Event.VertexAddedEvent>, TraversalParent, Parameterizing, Scoping {
 
-    private Parameters parameters = new Parameters();
+    private Parameters parameters;
     private boolean first = true;
     private CallbackRegistry<Event.VertexAddedEvent> callbackRegistry;
 
     public SqlgAddVertexStartStep(final Traversal.Admin traversal, Parameters parameters) {
         super(traversal);
         this.parameters = parameters;
+    }
+
+    @Override
+    public void configure(final Object... keyValues) {
+        this.parameters.set(this, keyValues);
     }
 
     @Override
@@ -46,11 +52,6 @@ public class SqlgAddVertexStartStep extends SqlgAbstractStep<Vertex, Vertex> imp
     @Override
     public <S, E> List<Traversal.Admin<S, E>> getLocalChildren() {
         return this.parameters.getTraversals();
-    }
-
-    @Override
-    public void addPropertyMutations(final Object... keyValues) {
-        this.parameters.set(this, keyValues);
     }
 
     @Override

--- a/sqlg-core/src/main/java/org/umlg/sqlg/step/barrier/SqlgDropStepBarrier.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/step/barrier/SqlgDropStepBarrier.java
@@ -7,6 +7,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Mutating;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.Parameters;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.CallbackRegistry;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.Event;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.ListCallbackRegistry;
@@ -32,6 +33,7 @@ public class SqlgDropStepBarrier<S> extends SqlgFilterStep<S>  implements Mutati
     private CallbackRegistry<Event> callbackRegistry;
     private final SqlgGraph sqlgGraph;
     private boolean first = true;
+    private final Parameters parameters = new Parameters();
     private final Set<RecordId> idsToDelete = new HashSet<>();
     private final MultiValuedMap<Pair<EdgeLabel, VertexLabel>, RecordId.ID> foreignKeyOutEdgesToDelete = new HashSetValuedHashMap<>();
     private final MultiValuedMap<Pair<EdgeLabel, VertexLabel>, RecordId.ID> foreignKeyInEdgesToDelete = new HashSetValuedHashMap<>();
@@ -42,6 +44,19 @@ public class SqlgDropStepBarrier<S> extends SqlgFilterStep<S>  implements Mutati
         super(traversal);
         this.sqlgGraph = (SqlgGraph) traversal.getGraph().get();
         this.callbackRegistry = callbackRegistry;
+    }
+
+    /**
+     * This method doesn't do anything as {@code drop()} doesn't take property mutation arguments.
+     */
+    @Override
+    public void configure(final Object... keyValues) {
+        // Do nothing.
+    }
+
+    @Override
+    public Parameters getParameters() {
+        return parameters;
     }
 
     @Override
@@ -181,12 +196,5 @@ public class SqlgDropStepBarrier<S> extends SqlgFilterStep<S>  implements Mutati
     public CallbackRegistry<Event> getMutatingCallbackRegistry() {
         if (null == callbackRegistry) callbackRegistry = new ListCallbackRegistry<>();
         return callbackRegistry;
-    }
-
-    /**
-     * This method doesn't do anything as {@code drop()} doesn't take property mutation arguments.
-     */
-    public void addPropertyMutations(final Object... keyValues) {
-        // do nothing
     }
 }

--- a/sqlg-core/src/main/java/org/umlg/sqlg/step/barrier/SqlgRepeatStepBarrier.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/step/barrier/SqlgRepeatStepBarrier.java
@@ -298,7 +298,8 @@ public class SqlgRepeatStepBarrier<S> extends SqlgComputerAwareStep<S, S> implem
                         while (this.starts.hasNext()) {
                             foundSomething = true;
                             Traverser.Admin<S> start = starts.next();
-                            start.incrLoops(this.getId());
+                            start.initialiseLoops(this.getId(), null);
+                            start.incrLoops();
                             repeatStep.addStart(start);
                             if (repeatStep.doEmit(start, false)) {
                                 final Traverser.Admin<S> emitSplit = start.split();
@@ -314,7 +315,8 @@ public class SqlgRepeatStepBarrier<S> extends SqlgComputerAwareStep<S, S> implem
                     while (this.starts.hasNext()) {
                         foundSomething = true;
                         Traverser.Admin<S> cachedStart = this.starts.next();
-                        cachedStart.incrLoops(this.getId());
+                        cachedStart.initialiseLoops(this.getId(), null);
+                        cachedStart.incrLoops();
                         if (repeatStep.doUntil(cachedStart, false)) {
                             cachedStart.resetLoops();
                             toReturn.add(IteratorUtils.of(cachedStart));
@@ -393,7 +395,8 @@ public class SqlgRepeatStepBarrier<S> extends SqlgComputerAwareStep<S, S> implem
         while (starts.hasNext()) {
             foundSomething = true;
             Traverser.Admin<S> cachedStart = starts.next();
-            cachedStart.incrLoops(this.getId());
+            cachedStart.initialiseLoops(this.getId(), null);
+            cachedStart.incrLoops();
             List<Object> startObjects = cachedStart.path().objects();
             StringBuilder recordIdConcatenated = new StringBuilder();
             for (Object startObject : startObjects) {

--- a/sqlg-core/src/main/java/org/umlg/sqlg/util/SqlgUtil.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/util/SqlgUtil.java
@@ -889,8 +889,14 @@ public class SqlgUtil {
                 ResultSet rs = statement.executeQuery("SELECT 1 FROM pg_roles WHERE rolname='sqlgReadOnly'");
                 if (rs.next()) {
                     try (Statement s = conn.createStatement()) {
-                        s.execute("REVOKE ALL PRIVILEGES ON SCHEMA public FROM \"sqlgReadOnly\"");
+                        s.execute("REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM \"sqlgReadOnly\"");
+                        s.execute("REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public FROM \"sqlgReadOnly\"");
+                        s.execute("REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public FROM \"sqlgReadOnly\"");
                         s.execute("REVOKE USAGE ON SCHEMA public FROM \"sqlgReadOnly\"");
+                        s.execute("REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA gui_schema FROM \"sqlgReadOnly\"");
+                        s.execute("REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA gui_schema FROM \"sqlgReadOnly\"");
+                        s.execute("REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA gui_schema FROM \"sqlgReadOnly\"");
+                        s.execute("REVOKE USAGE ON SCHEMA gui_schema FROM \"sqlgReadOnly\"");
                         s.execute("DROP ROLE \"sqlgReadOnly\"");
                     } catch (SQLException e) {
                         throw new RuntimeException(e);

--- a/sqlg-core/src/main/java/org/umlg/sqlg/util/SqlgUtil.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/util/SqlgUtil.java
@@ -889,14 +889,20 @@ public class SqlgUtil {
                 ResultSet rs = statement.executeQuery("SELECT 1 FROM pg_roles WHERE rolname='sqlgReadOnly'");
                 if (rs.next()) {
                     try (Statement s = conn.createStatement()) {
+                        // Revokes all privileges against the public Postgres schema.
                         s.execute("REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM \"sqlgReadOnly\"");
                         s.execute("REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public FROM \"sqlgReadOnly\"");
                         s.execute("REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public FROM \"sqlgReadOnly\"");
                         s.execute("REVOKE USAGE ON SCHEMA public FROM \"sqlgReadOnly\"");
-                        s.execute("REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA gui_schema FROM \"sqlgReadOnly\"");
-                        s.execute("REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA gui_schema FROM \"sqlgReadOnly\"");
-                        s.execute("REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA gui_schema FROM \"sqlgReadOnly\"");
-                        s.execute("REVOKE USAGE ON SCHEMA gui_schema FROM \"sqlgReadOnly\"");
+
+                        // If gui_schema has been created, we must revoke privileges against it as well.
+                        ResultSet rs2 = statement.executeQuery("SELECT 1 FROM information_schema.schemata WHERE schema_name = 'gui_schema'");
+                        if (rs2.next()) {
+                            s.execute("REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA gui_schema FROM \"sqlgReadOnly\"");
+                            s.execute("REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA gui_schema FROM \"sqlgReadOnly\"");
+                            s.execute("REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA gui_schema FROM \"sqlgReadOnly\"");
+                            s.execute("REVOKE USAGE ON SCHEMA gui_schema FROM \"sqlgReadOnly\"");
+                        }
                         s.execute("DROP ROLE \"sqlgReadOnly\"");
                     } catch (SQLException e) {
                         throw new RuntimeException(e);

--- a/sqlg-core/src/main/java/org/umlg/sqlg/util/SqlgUtil.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/util/SqlgUtil.java
@@ -890,6 +890,7 @@ public class SqlgUtil {
                 if (rs.next()) {
                     try (Statement s = conn.createStatement()) {
                         s.execute("REVOKE ALL PRIVILEGES ON SCHEMA public FROM \"sqlgReadOnly\"");
+                        s.execute("REVOKE USAGE ON SCHEMA public FROM \"sqlgReadOnly\"");
                         s.execute("DROP ROLE \"sqlgReadOnly\"");
                     } catch (SQLException e) {
                         throw new RuntimeException(e);

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/event/TestTinkerPopEvent.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/event/TestTinkerPopEvent.java
@@ -99,7 +99,7 @@ public class TestTinkerPopEvent extends BaseTest {
         }
 
         @Override
-        public void vertexPropertyChanged(final Vertex element, final Property oldValue, final Object setValue, final Object... vertexPropertyKeyValues) {
+        public void vertexPropertyChanged(Vertex element, VertexProperty oldValue, Object setValue, Object... vertexPropertyKeyValues) {
 
         }
 

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/mod/TestTraversalAddV.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/mod/TestTraversalAddV.java
@@ -93,7 +93,7 @@ public class TestTraversalAddV extends BaseTest {
         }
 
         @Override
-        public void vertexPropertyChanged(final Vertex element, final Property oldValue, final Object setValue, final Object... vertexPropertyKeyValues) {
+        public void vertexPropertyChanged(Vertex element, VertexProperty oldValue, Object setValue, Object... vertexPropertyKeyValues) {
 
         }
 

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/process/dropstep/TestDropStep.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/process/dropstep/TestDropStep.java
@@ -9,8 +9,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.MutationListener;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.EventStrategy;
 import org.apache.tinkerpop.gremlin.structure.*;
-import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedFactory;
-import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceFactory;
 import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceVertex;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.hamcrest.CoreMatchers;

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/process/dropstep/TestDropStep.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/process/dropstep/TestDropStep.java
@@ -9,6 +9,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.MutationListener;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.EventStrategy;
 import org.apache.tinkerpop.gremlin.structure.*;
+import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedFactory;
 import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceFactory;
 import org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceVertex;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
@@ -280,7 +281,8 @@ public class TestDropStep extends BaseTest {
                 triggered.set(true);
             }
         };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(ReferenceFactory.class);
+        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener)
+            .detach(EventStrategy.Detachment.REFERENCE);
 
         if (this.sqlgGraph.features().graph().supportsTransactions())
             builder.eventQueue(new EventStrategy.TransactionalEventQueue(this.sqlgGraph));
@@ -321,7 +323,8 @@ public class TestDropStep extends BaseTest {
                 triggered.set(true);
             }
         };
-        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener).detach(ReferenceFactory.class);
+        final EventStrategy.Builder builder = EventStrategy.build().addListener(listener)
+            .detach(EventStrategy.Detachment.REFERENCE);
 
         if (this.sqlgGraph.features().graph().supportsTransactions())
             builder.eventQueue(new EventStrategy.TransactionalEventQueue(this.sqlgGraph));
@@ -1636,7 +1639,8 @@ public class TestDropStep extends BaseTest {
         }
 
         @Override
-        public void vertexPropertyChanged(final Vertex element, final Property oldValue, final Object setValue, final Object... vertexPropertyKeyValues) {
+        public void vertexPropertyChanged(Vertex element, VertexProperty oldValue,
+                                          Object setValue, Object... vertexPropertyKeyValues) {
 
         }
 

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/process/dropstep/TestDropStepBarrier.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/process/dropstep/TestDropStepBarrier.java
@@ -717,7 +717,7 @@ public class TestDropStepBarrier extends BaseTest {
         }
 
         @Override
-        public void vertexPropertyChanged(final Vertex element, final Property oldValue, final Object setValue, final Object... vertexPropertyKeyValues) {
+        public void vertexPropertyChanged(Vertex element, VertexProperty oldValue, Object setValue, Object... vertexPropertyKeyValues) {
 
         }
 

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/process/dropstep/TestDropStepTruncate.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/process/dropstep/TestDropStepTruncate.java
@@ -134,7 +134,7 @@ public class TestDropStepTruncate extends BaseTest {
         }
 
         @Override
-        public void vertexPropertyChanged(final Vertex element, final Property oldValue, final Object setValue, final Object... vertexPropertyKeyValues) {
+        public void vertexPropertyChanged(Vertex element, VertexProperty oldValue, Object setValue, Object... vertexPropertyKeyValues) {
 
         }
 

--- a/sqlg-test/src/main/java/org/umlg/sqlg/test/properties/TestPropertyValues.java
+++ b/sqlg-test/src/main/java/org/umlg/sqlg/test/properties/TestPropertyValues.java
@@ -198,12 +198,12 @@ public class TestPropertyValues extends BaseTest {
     @Test
     public void testValueMapOneObject() {
         loadModern();
-        final Traversal<Vertex, Map<String, Object>> traversal = sqlgGraph.traversal().V().hasLabel("person").valueMap("name");
+        final Traversal<Vertex, Map<Object, Object>> traversal = sqlgGraph.traversal().V().hasLabel("person").valueMap("name");
         checkColumnsNotPresent(traversal, "age");
         checkRestrictedProperties(SqlgGraphStep.class, traversal, 0, "name");
         Set<String> names = new HashSet<>();
         while (traversal.hasNext()) {
-            Map<String, Object> m = traversal.next();
+            Map<Object, Object> m = traversal.next();
             Assert.assertNotNull(m);
             Assert.assertEquals(1, m.size());
             Assert.assertTrue(m.containsKey("name"));
@@ -222,13 +222,13 @@ public class TestPropertyValues extends BaseTest {
     @Test
     public void testValueMapAllObject() {
         loadModern();
-        final Traversal<Vertex, Map<String, Object>> traversal = sqlgGraph.traversal().V().hasLabel("person").valueMap();
+        final Traversal<Vertex, Map<Object, Object>> traversal = sqlgGraph.traversal().V().hasLabel("person").valueMap();
         printTraversalForm(traversal);
         checkNoRestrictedProperties(traversal);
         Set<String> names = new HashSet<>();
         Set<Integer> ages = new HashSet<>();
         while (traversal.hasNext()) {
-            Map<String, Object> m = traversal.next();
+            Map<Object, Object> m = traversal.next();
             Assert.assertNotNull(m);
             Assert.assertEquals(2, m.size());
             Assert.assertTrue(m.containsKey("name"));

--- a/sqlg-testdb-postgres/Dockerfile
+++ b/sqlg-testdb-postgres/Dockerfile
@@ -1,4 +1,3 @@
 FROM postgres:9.6-alpine
 
 COPY sqlg-setup.sql docker-entrypoint-initdb.d/
-

--- a/sqlg-testdb-postgres/docker-compose.yml
+++ b/sqlg-testdb-postgres/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "2"
+services:
+  sqlg-test-postgres:
+    build: .
+    privileged: true
+    ports:
+      - "9700:5432"

--- a/sqlg-testdb-postgres/docker-compose.yml
+++ b/sqlg-testdb-postgres/docker-compose.yml
@@ -1,7 +1,13 @@
 version: "2"
 services:
-  sqlg-test-postgres:
+  sqlg-test-postgres-9700:
     build: .
     privileged: true
     ports:
       - "9700:5432"
+
+  sqlg-test-postgres-5432:
+    build: .
+    privileged: true
+    ports:
+      - "5432:5432"

--- a/sqlg-testdb-postgres/sqlg-setup.sql
+++ b/sqlg-testdb-postgres/sqlg-setup.sql
@@ -1,5 +1,5 @@
 ALTER SYSTEM SET max_connections TO '1000';
-ALTER SYSTEM SET max_locks_per_transaction TO '256';
+ALTER SYSTEM SET max_locks_per_transaction TO '1024';
 ALTER SYSTEM SET shared_buffers TO '1024MB';
 
 CREATE DATABASE "sqlgraphdb";

--- a/sqlg-testdb-postgres/start.sh
+++ b/sqlg-testdb-postgres/start.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Establishes Postgres database suitable for testing purposes.
+
+docker-compose up --force-recreate -d


### PR DESCRIPTION
This PR upgrades both TInkerpop to version 3.4.1 and SLF4J to version 1.7.25 to enable compatibility with sqlg consumer libraries, such as gremlin-scala. The Tinkerpop upgrade introduced numerous API refactors which I've adapted here, most of them largely no-ops to ensure conformance.

To test that these adaptations haven't introduced any weird bugs into the codebase, I've reconfigured the Travis CI buildfile and Docker build scripting to support the Postgres defaults encoded within the sqlg test suite. The Postgres dialect-facing tests ran cleanly, as did all other non-DB specific tests, but several targets such as the MySQL and MS SQL Server integration suites did not, as we have not yet set up databases for these tests.

With the introduction of a docker-compose file, included here, we should be able to add support for all remaining databases and integrate full functional/integration tests for branch and master integrations. As these machines run with 2 cores, we should be able to have everything run under the 50 minute limit with 4 Maven threads. I'd be happy to take this on in a future review as we continue our sqlg integration over here.

Let me know what you think and thanks for the consideration!