### PR TITLE
Adds support for creating all necessary Sqlg schemas in a MySQL database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ src/test/db/
 /sqlg-benchmark-hsqldb/src/test/db/
 /sqlg-h2-parent/sqlg-h2/src/test/db/
 /sqlg-benchmark-h2/src/test/db/
+.DS_Store
 
 ### Eclipse files
 **/.classpath

--- a/sqlg-mysql-parent/sqlg-mysql-dialect/src/main/java/org/umlg/sqlg/sql/dialect/MysqlDialect.java
+++ b/sqlg-mysql-parent/sqlg-mysql-dialect/src/main/java/org/umlg/sqlg/sql/dialect/MysqlDialect.java
@@ -727,7 +727,7 @@ public class MysqlDialect extends BaseSqlDialect {
         List<String> result = new ArrayList<>();
 
         //SERIAL is an alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE
-        result.add("CREATE TABLE IF NOT EXISTS `sqlg_schema`.`V_graph` (`ID` SERIAL PRIMARY KEY, `createdOn` DATETIME, `updatedOn` DATETIME, `version` TEXT);");
+        result.add("CREATE TABLE IF NOT EXISTS `sqlg_schema`.`V_graph` (`ID` SERIAL PRIMARY KEY, `createdOn` DATETIME, `updatedOn` DATETIME, `version` TEXT, `dbVersion` TEXT);");
         result.add("CREATE TABLE IF NOT EXISTS `sqlg_schema`.`V_schema` (`ID` SERIAL PRIMARY KEY, `createdOn` DATETIME, `name` TEXT);");
         result.add("CREATE TABLE IF NOT EXISTS `sqlg_schema`.`V_vertex` (`ID` SERIAL PRIMARY KEY, `createdOn` DATETIME, `name` TEXT, `schemaVertex` TEXT);");
         result.add("CREATE TABLE IF NOT EXISTS `sqlg_schema`.`V_edge` (`ID` SERIAL PRIMARY KEY, `createdOn` DATETIME, `name` TEXT);");
@@ -813,6 +813,7 @@ public class MysqlDialect extends BaseSqlDialect {
 
         result.add("CREATE TABLE IF NOT EXISTS `sqlg_schema`.`V_log`(`ID` SERIAL PRIMARY KEY, `timestamp` DATETIME, `pid` INTEGER, `log` TEXT);");
 
+        result.addAll(addPartitionTables());
         return result;
     }
 


### PR DESCRIPTION
At the moment, MySQL databases cannot be brought up from scratch as the `dbVersion` field on the `sqlg_schema.V_graph` table is not present and is expected by the `SqlgGraphStartupManager`. Furthermore, while partitioning is not supported on MySQL, the `SqlgGraphStartupManager` expects certain tables and fields from it to be present, so we must create them even if they are not used at present.

With these changes, the `SqlgGraphStartupManager` can successfully create all necessary schemas within an empty MySQL database.

Let me know what you think and thanks for the consideration!