### PR TITLE
cherry-pick 7330f240: use "sqlg.index" instead of "index" for custom required sql field so as not to clash with existing columns

### DIFF
--- a/sqlg-core/src/main/java/org/umlg/sqlg/sql/parse/SchemaTableTree.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/sql/parse/SchemaTableTree.java
@@ -103,6 +103,8 @@ public class SchemaTableTree {
     private List<Pair<RecordId.ID, Long>> parentIdsAndIndexes;
     private Set<String> restrictedProperties = null;
     private boolean eagerLoad = false;
+    
+    public static final String TMP_INDEX_FIELD = "sqlg_index";
 
     private List<String> groupBy = null;
     private Pair<String, List<String>> aggregateFunction = null;
@@ -222,11 +224,11 @@ public class SchemaTableTree {
             result.append(lastSchemaTableTree.toOuterGroupByClause(sqlgGraph, "a" + subQueryLinkedLists.size()));
             if (!dropStep && subQueryLinkedLists.get(0).getFirst().stepType != STEP_TYPE.GRAPH_STEP) {
                 result.append(",\n\t");
-                result.append(sqlgGraph.getSqlDialect().maybeWrapInQoutes("index"));
+                result.append(sqlgGraph.getSqlDialect().maybeWrapInQoutes(TMP_INDEX_FIELD));
             }
         } else if (lastSchemaTableTree.hasAggregateFunction() && !dropStep && subQueryLinkedLists.get(0).getFirst().stepType != STEP_TYPE.GRAPH_STEP) {
             result.append("\nGROUP BY\n\t");
-            result.append(sqlgGraph.getSqlDialect().maybeWrapInQoutes("index"));
+            result.append(sqlgGraph.getSqlDialect().maybeWrapInQoutes(TMP_INDEX_FIELD));
         }
         return result.toString();
     }
@@ -875,8 +877,8 @@ public class SchemaTableTree {
 
 
             if (first && subQueryLinkedLists.get(0).getFirst().stepType != STEP_TYPE.GRAPH_STEP) {
-                result.append("a1.").append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes("index")).append(" as ")
-                        .append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes("index"))
+                result.append("a1.").append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes(TMP_INDEX_FIELD)).append(" as ")
+                        .append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes(TMP_INDEX_FIELD))
                         .append(",\n\r");
 
                 columnStartIndex++;
@@ -940,11 +942,11 @@ public class SchemaTableTree {
             if (!this.sqlgGraph.getSqlDialect().isMssqlServer() && this.parentIdsAndIndexes.size() == 1) {
                 singlePathSql.append(this.parentIdsAndIndexes.get(0).getRight());
                 singlePathSql.append(" as ");
-                singlePathSql.append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes("index"));
+                singlePathSql.append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes(TMP_INDEX_FIELD));
             } else if (this.sqlgGraph.getSqlDialect().supportsValuesExpression()) {
                 //Hardcoding here for H2
                 if (this.sqlgGraph.getSqlDialect().supportsFullValueExpression()) {
-                    singlePathSql.append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes("index"));
+                    singlePathSql.append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes(TMP_INDEX_FIELD));
                 } else {
                     if (firstSchemaTableTree.hasIDPrimaryKey) {
                         singlePathSql.append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes("C2"));
@@ -953,14 +955,14 @@ public class SchemaTableTree {
                     }
                 }
                 singlePathSql.append(" as ");
-                singlePathSql.append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes("index"));
+                singlePathSql.append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes(TMP_INDEX_FIELD));
             } else {
-                singlePathSql.append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes("index"));
+                singlePathSql.append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes(TMP_INDEX_FIELD));
                 singlePathSql.append(" as ");
-                singlePathSql.append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes("index"));
+                singlePathSql.append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes(TMP_INDEX_FIELD));
             }
             singlePathSql.append(",\n\t");
-            //increment the ColumnList's index to take the "index" field into account.
+            //increment the ColumnList's index to take the TMP_INDEX_FIELD field into account.
             startIndexColumns++;
         }
 
@@ -1052,7 +1054,7 @@ public class SchemaTableTree {
                             singlePathSql.append(", ");
                         }
                     }
-                    singlePathSql.append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes("index"));
+                    singlePathSql.append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes(TMP_INDEX_FIELD));
                     singlePathSql.append(") ON ");
 
                     if (firstSchemaTableTree.hasIDPrimaryKey) {
@@ -1119,7 +1121,7 @@ public class SchemaTableTree {
                         this.sqlgGraph.addTemporaryVertex(
                                 T.label, tmpTableIdentified,
                                 "tmpId", parentIdsAndIndex.getLeft().getSequenceId(),
-                                "index", parentIdsAndIndex.getRight());
+                                TMP_INDEX_FIELD, parentIdsAndIndex.getRight());
                     } else {
                         List<Object> keyValues = new ArrayList<>();
                         keyValues.add(T.label);
@@ -1129,7 +1131,7 @@ public class SchemaTableTree {
                             keyValues.add(identifier);
                             keyValues.add(parentIdsAndIndex.getLeft().getIdentifiers().get(count++));
                         }
-                        keyValues.add("index");
+                        keyValues.add(TMP_INDEX_FIELD);
                         keyValues.add(parentIdsAndIndex.getRight());
                         this.sqlgGraph.addTemporaryVertex(keyValues.toArray());
                     }
@@ -1217,7 +1219,7 @@ public class SchemaTableTree {
                 singlePathSql.append(lastSchemaTableTree.toGroupByClause(this.sqlgGraph));
                 if (!dropStep && lastOfPrevious == null && distinctQueryStack.getFirst().stepType != STEP_TYPE.GRAPH_STEP) {
                     singlePathSql.append(",\n\t");
-                    singlePathSql.append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes("index"));
+                    singlePathSql.append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes(TMP_INDEX_FIELD));
                 }
             } else if (lastSchemaTableTree.hasAggregateFunction() &&
                     !dropStep &&
@@ -1225,12 +1227,12 @@ public class SchemaTableTree {
                     distinctQueryStack.getFirst().stepType != STEP_TYPE.GRAPH_STEP) {
 
                 singlePathSql.append("\nGROUP BY\n\t");
-                singlePathSql.append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes("index"));
+                singlePathSql.append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes(TMP_INDEX_FIELD));
             }
 
             if (!dropStep && lastOfPrevious == null && distinctQueryStack.getFirst().stepType != STEP_TYPE.GRAPH_STEP) {
                 singlePathSql.append("\nORDER BY\n\t");
-                singlePathSql.append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes("index"));
+                singlePathSql.append(this.sqlgGraph.getSqlDialect().maybeWrapInQoutes(TMP_INDEX_FIELD));
                 mutableOrderBy.setTrue();
             }
 
@@ -2704,7 +2706,7 @@ public class SchemaTableTree {
         for (ColumnList columnList : this.getRootColumnListStack()) {
             LinkedHashMap<ColumnList.Column, String> columns = columnList.getFor(this.stepDepth, this.schemaTable);
             for (ColumnList.Column column : columns.keySet()) {
-                if (!column.getColumn().equals("index") && !column.isID() && !column.isForeignKey()) {
+                if (!column.getColumn().equals(TMP_INDEX_FIELD) && !column.isID() && !column.isForeignKey()) {
                     String propertyName = column.getColumn();
                     PropertyType propertyType = column.getPropertyType();
                     boolean settedProperty;

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/topology/Topology.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/topology/Topology.java
@@ -325,7 +325,7 @@ public class Topology {
 
     /**
      * Topology is a singleton created when the {@link SqlgGraph} is opened.
-     * As the topology, i.e. sqlg_schema is created upfront the meta topology is pre-loaded.
+     * As the topology, i.e. sqlg_schema is created upfront the meta topology is preloaded.
      *
      * @param sqlgGraph The graph.
      */


### PR DESCRIPTION
https://github.com/pietermartin/sqlg/releases/tag/2.1.6
git checkout -b 2.1.6 283d75eb90486eb2a7b5a91c7ea5fe990b37ab90
git cherry-pick 7330f24047e4bf8761b9b93f597742b3400101c1
