### PR TITLE
TopologyChangeListener should fallback to pool connection

### DIFF
--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgStartupManager.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/SqlgStartupManager.java
@@ -108,6 +108,7 @@ class SqlgStartupManager {
                 String version = getBuildVersion();
                 String oldVersion = createOrUpdateGraph(version);
                 int versionAsInt = Integer.parseInt(oldVersion.replace("-SNAPSHOT", "").replace(".", ""));
+                LOGGER.debug(String.format("loadSqlgSchema() version=%s, oldVersion=%s, versionAsInt=%s", version, oldVersion, versionAsInt));
                 if (versionAsInt < 203) {
                     //Need to check if there are any timestampz or timetz columns.
                     //If so throw an exception as the user needs to alter them to drop the 'z'
@@ -164,6 +165,7 @@ class SqlgStartupManager {
         if (oldVersion != null) {
             v = VersionUtil.parseVersion(oldVersion, null, null);
         }
+        LOGGER.debug(String.format("updateTopology() v=%s",v));
         if (v.isUnknownVersion() || v.compareTo(new Version(1, 5, 0, null, null, null)) < 0) {
             if (this.sqlDialect.supportsDeferrableForeignKey()) {
                 upgradeForeignKeysToDeferrable();


### PR DESCRIPTION
Our system uses AWS IAM role to authenticate to a postgresql database. Therefore, jdbcPassword property is not set because it would be a short live token value

Before the fix, it fails with error

```
2026-01-12 03:40:39.914 +0000 (,,,,) Sqlg notification listener sqlggraph[SqlGraph] (jdbc:postgresql://ol-dev-dp1-datacat-db.c9ia9lopo6ka.us-west-2.rds.amazonaws.com:5432/RelationshipBlue) (user = catalog_iam_query) : ERROR org.umlg.sqlg.dialect.impl.PostgresDialect - change listener on graph sqlggraph[SqlGraph] (jdbc:postgresql://ol-dev-dp1-datacat-db.c9ia9lopo6ka.us-west-2.rds.amazonaws.com:5432/RelationshipBlue) (user = catalog_iam_query) error
org.postgresql.util.PSQLException: FATAL: empty password returned by client
at org.postgresql.core.v3.ConnectionFactoryImpl.doAuthentication(ConnectionFactoryImpl.java:778) ~[postgresql-42.7.8.jar!/:42.7.8]
at org.postgresql.core.v3.ConnectionFactoryImpl.tryConnect(ConnectionFactoryImpl.java:234) ~[postgresql-42.7.8.jar!/:42.7.8]
at org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:289) ~[postgresql-42.7.8.jar!/:42.7.8]
at org.postgresql.core.ConnectionFactory.openConnection(ConnectionFactory.java:57) ~[postgresql-42.7.8.jar!/:42.7.8]
at org.postgresql.jdbc.PgConnection.<init>(PgConnection.java:279) ~[postgresql-42.7.8.jar!/:42.7.8]
at org.postgresql.Driver.makeConnection(Driver.java:448) ~[postgresql-42.7.8.jar!/:42.7.8]
at org.postgresql.Driver.connect(Driver.java:298) ~[postgresql-42.7.8.jar!/:42.7.8]
at java.sql/java.sql.DriverManager.getConnection(DriverManager.java:681) ~[java.sql:?]
at java.sql/java.sql.DriverManager.getConnection(DriverManager.java:190) ~[java.sql:?]
at org.umlg.sqlg.dialect.impl.PostgresDialect$TopologyChangeListener.run(PostgresDialect.java:3487) [sqlg-postgres-dialect-3.1.3.jar!/:3.1.3]
at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) [?:?]
at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) [?:?]
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
at java.base/java.lang.Thread.run(Thread.java:840) [?:?]
```